### PR TITLE
chore: font face 설정 오류 개선, 기본값 regular로 재지정 

### DIFF
--- a/src/styles/font.ts
+++ b/src/styles/font.ts
@@ -4,13 +4,13 @@ export const FontCSS = css`
   @font-face {
     font-family: 'Pretendard';
     font-style: normal;
-    font-weight: regular;
+    font-weight: normal;
     src: url('/fonts/Pretendard-Regular.woff') format('woff');
   }
   @font-face {
     font-family: 'Pretendard';
     font-style: normal;
-    font-weight: medium;
+    font-weight: 500;
     src: url('/fonts/Pretendard-Medium.woff') format('woff');
   }
   @font-face {

--- a/src/styles/global.tsx
+++ b/src/styles/global.tsx
@@ -8,7 +8,8 @@ const globalStyle = css`
   }
 
   body {
-    font-family: Pretendard regular;
+    font-family: Pretendard;
+    font-weight: normal;
   }
 `
 

--- a/src/styles/themes/fonts.ts
+++ b/src/styles/themes/fonts.ts
@@ -18,14 +18,14 @@ export const fonts: Fonts = {
   body01: {
     bold: 'font-size: 16px; font-weight: bold; line-height: 24px; letter-spacing: -0.6%;',
     medium:
-      'font-size: 16px; font-weight: medium; line-height: 24px; letter-spacing: -0.6%;',
+      'font-size: 16px; font-weight: 500; line-height: 24px; letter-spacing: -0.6%;',
     regular:
       'font-size: 16px; font-weight: regular; line-height: 24px; letter-spacing: -0.6%;'
   },
   body02: {
     bold: 'font-size: 14px; font-weight: bold; line-height: 24px; letter-spacing: -0.6%;',
     long: 'font-size: 14px; font-weight: regular; line-height: 26px; letter-spacing: -0.4%;',
-    medium: 'font-size: 14px; font-weight: medium; line-height: 20px;',
+    medium: 'font-size: 14px; font-weight: 500; line-height: 20px;',
     regular:
       'font-size: 14px; font-weight: regular; line-height: 14px; letter-spacing: -0.4%;'
   },
@@ -35,13 +35,13 @@ export const fonts: Fonts = {
     'font-size: 36px; font-weight: bold; line-height: 40px; letter-spacing: -0.6%;',
   display02: {
     bold: 'font-size: 28px; font-weight: bold; line-height: 28px;',
-    medium: 'font-size: 28px; font-weight: medium; line-height: 28px;'
+    medium: 'font-size: 28px; font-weight: 500; line-height: 28px;'
   },
   headline01: 'font-size: 24px; font-weight: bold; line-height: 32px;',
   headline02: 'font-size: 20px; font-weight: bold; line-height: 28px;',
   subtitle01: {
     bold: 'font-size: 18px; font-weight: bold; line-height: 22px; letter-spacing: -0.6%;',
     medium:
-      'font-size: 18px; font-weight: medium; line-height: 22px; letter-spacing: -0.4%;'
+      'font-size: 18px; font-weight: 500; line-height: 22px; letter-spacing: -0.4%;'
   }
 } as const


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #23 

## ⛳ 구현 사항
- font-family에 잘못 정의해둔 폰트명을 수정하였습니다.
- font-weight 400이 기본 값으로 적용되어 medium이 기본값으로 설정이 되어 500으로 따로 정의해주었습니다
  - theme/font.ts의 medium 대신 500을 사용할 수 있도록 반영 해 두었습니다.

폰트 설정으로 번거롭게 해서 죄송해융 ㅠㅅㅠ!!

## 📚 구현 설명
**font-weight**
- normal: regular
- 500: medium
- bold: bold
좌측 값으로 설정하게 되면 font weight가 적용됩니다!

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->