### PR TITLE
config: eslint 설정 변경

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,6 @@
   ],
   "rules": {
     "sort-imports": ["error", { "ignoreCase": true }],
-    "consistent-return": ["error", { "treatUndefinedAsUnspecified": true }],
     "default-case-last": "error",
     "func-style": ["error", "expression"],
     "no-console": "error",
@@ -39,10 +38,13 @@
     ],
     "react/jsx-pascal-case": ["error"],
     "react/react-in-jsx-scope": "off",
-    "react/self-closing-comp": ["error", {
-      "component": true,
-      "html": true
-    }],
+    "react/self-closing-comp": [
+      "error",
+      {
+        "component": true,
+        "html": true
+      }
+    ],
     "@typescript-eslint/array-type": ["error", { "default": "array" }],
     "@typescript-eslint/ban-tslint-comment": "error",
     "@typescript-eslint/consistent-indexed-object-style": [


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #42 

## ⛳ 구현 사항
- [ ] consistent-return 제거

## 📚 구현 설명
- useEffect를 사용하면서 발생한 lint 에러를 해결하기 위해 `consistent-return` 룰을 제거
 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

 ## 🔥 이슈와 해결 방안 
- useEffect를 사용할 때 `consistent-return`에러 발생
   - 이슈 원인
      - early return 타입과, cleanUp return의 타입이 달라서 발생하는 에러
   - 시도한 방법
      - early return 시 cleanUp return 타입인 `() => void`와 맞추기 위해 `return () => null`을 사용
   - 해결 방안
      - lint 룰에서 `consistent-return`을 제거
      
  <img width="606" alt="스크린샷 2022-09-17 오전 3 56 45" src="https://user-images.githubusercontent.com/70738281/190712367-77f1fa99-f833-4560-ab27-0c1c28b9d483.png">

   

<!-- ## 🛠 피드백 반영 사항 -->