### PR TITLE
fix: 캐러젤 터치슬라이드 이벤트가 간헐적으로 안되는 현상 수정

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -300,7 +300,6 @@ export const StyledIndicator = styled.div`
     width: 8px;
     height: 8px;
     background-color: ${({ theme }): string => theme.colors.background.white};
-    opacity: 0.5;
     box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.4);
   }
 `
@@ -312,7 +311,6 @@ export const StyledCurrentIndicator = styled.div<CurrentIndicatorProps>`
   position: absolute;
   left: 0;
   top: 50%;
-  font-size: 20px;
   margin: 0 1px;
   border-radius: 100px;
   cursor: pointer;

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -99,15 +99,20 @@ const Carousel = ({
       endClientX > startClientX && dragSpace > USER_DRAG_LENGTH
     const userSlideLeft =
       endClientX < startClientX && dragSpace > USER_DRAG_LENGTH
+
     if (startClientX === 0) {
       return
     }
     if (userSlideRight) {
       handleOffset(NAV_TYPE.RIGHT)
+      setStartClientX(0)
+      setEndClientX(0)
     } else if (userSlideLeft) {
       handleOffset(NAV_TYPE.LEFT)
+      setStartClientX(0)
+      setEndClientX(0)
     }
-  }, [endClientX])
+  }, [startClientX, endClientX])
 
   return (
     <StyledCarouselWrapper>

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -201,12 +201,10 @@ export const StyledSlider = styled.div<SliderProps>`
   ${({ theme }): string => theme.mediaQuery.tablet} {
     max-width: ${({ size }): string => `${size}vw`};
     height: 400px;
-    right: 20px;
   }
   ${({ theme }): string => theme.mediaQuery.mobile} {
     max-width: ${({ size }): string => `${size}vw`};
     height: 360px;
-    right: 20px;
   }
 `
 
@@ -249,14 +247,11 @@ export const StyledImage = styled.img<ImageProps>`
 export const StyledArrowBox = styled.div`
   position: absolute;
   top: 0;
-  left: -20px;
   width: 100%;
   height: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
-
   ${({ theme }): string => theme.mediaQuery.tablet} {
     display: none;
   }


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #50 

## ⛳ 구현 사항
캐러젤  터치슬라이드 이벤트가 반대 전환시 한번 무시되는 현상 수정

## 📚 구현 설명
이미지 전환 발생마다 x좌표 상태(StartClientX,EndClientX) 초기화 및 의존성에 추가하여 최신화 
 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->