### PR TITLE
chore: storybook logo,favicon 변경

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,2 @@
+<link rel="icon" type="image/png" sizes="192x192"
+    href="https://user-images.githubusercontent.com/66211721/193445904-9c0901a7-8105-4813-a066-b20718af86f0.png">

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons';
+import theme from './theme';
+
+addons.setConfig({
+  theme
+});

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -1,0 +1,6 @@
+import { create } from "@storybook/theming/create";
+
+export default create({
+brandTitle: "Offer",
+brandImage:'https://user-images.githubusercontent.com/66211721/193445902-c43f85c8-5152-444e-b158-2a5804bc7889.png',
+})


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #41 

## ⛳ 구현 사항
스토리북 로고, 파비콘 변경
## 📚 구현 설명
스토리북의 로고 및 파비콘변경 작업을 위해 ./storybook 폴더에 theme, manager-head를 추가하였습니다.
<img width="337" alt="image" src="https://user-images.githubusercontent.com/66211721/193446379-5ede4e3e-924f-4092-a3b2-66a3cb2b17b1.png">
