### PR TITLE
refactor: props명 통일, Button 컴포넌트 오타 수정

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -4,7 +4,7 @@ import type { BadgeProps } from './index'
 
 export default {
   argTypes: {
-    colorScheme: {
+    colorType: {
       control: { type: 'radio' },
       options: ['gray', 'orange', 'purple']
     }
@@ -16,4 +16,4 @@ export default {
 const Template: Story<BadgeProps> = args => <Badge {...args} />
 
 export const Default = Template.bind({})
-Default.args = { children: 'Badge', colorScheme: 'gray' }
+Default.args = { children: 'Badge', colorType: 'gray' }

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -2,24 +2,21 @@ import type { HTMLAttributes, ReactElement } from 'react'
 import type { Colors } from '@themes/colors'
 import styled from '@emotion/styled'
 
-type BadgeColorScheme = 'gray' | 'orange' | 'purple'
+type BadgeColorType = 'gray' | 'orange' | 'purple'
 export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
-  colorScheme: BadgeColorScheme
+  colorType: BadgeColorType
 }
 
-type StyledBadgeProps = Pick<BadgeProps, 'colorScheme'>
-type ApplyColorScheme = (
-  colorScheme: BadgeColorScheme,
-  colors: Colors
-) => string
+type StyledBadgeProps = Pick<BadgeProps, 'colorType'>
+type ApplyColorScheme = (colorType: BadgeColorType, colors: Colors) => string
 
 export const Badge = ({
-  colorScheme,
+  colorType,
   children,
   ...props
 }: BadgeProps): ReactElement => {
   return (
-    <StyledBadge colorScheme={colorScheme} {...props}>
+    <StyledBadge colorType={colorType} {...props}>
       {children}
     </StyledBadge>
   )
@@ -55,6 +52,6 @@ const StyledBadge = styled.div<StyledBadgeProps>`
   font-feature-settings: normal;
   ${({ theme }): string => theme.fonts.caption01M}
   font-weight: 500;
-  ${({ colorScheme, theme }): string =>
+  ${({ colorType: colorScheme, theme }): string =>
     applyColorScheme(colorScheme, theme.colors)};
 `

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -4,10 +4,6 @@ import type { ButtonProps } from './index'
 
 export default {
   argTypes: {
-    buttonStyle: {
-      control: { type: 'radio' },
-      options: Object.values(BUTTON_STYLE_KEYS)
-    },
     children: {
       control: { type: 'text' }
     },
@@ -17,6 +13,10 @@ export default {
     size: {
       control: { type: 'radio' },
       options: ['large', 'medium', 'small']
+    },
+    styleType: {
+      control: { type: 'radio' },
+      options: Object.values(BUTTON_STYLE_KEYS)
     }
   },
   component: Button,
@@ -27,8 +27,8 @@ const Template: Story<ButtonProps> = args => <Button {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  buttonStyle: 'ghost',
   children: 'CTA 버튼',
-  iconType: 'heart',
-  size: 'medium'
+  icon: 'heart',
+  size: 'medium',
+  styleType: 'ghost'
 }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -5,20 +5,20 @@ import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 import type { Theme } from '@emotion/react'
 
-type ButtonStyle = typeof BUTTON_STYLE_KEYS[keyof typeof BUTTON_STYLE_KEYS]
+type ButtonStyleType = typeof BUTTON_STYLE_KEYS[keyof typeof BUTTON_STYLE_KEYS]
 type ButtonSize = 'small' | 'medium' | 'large'
 export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
-  buttonStyle?: ButtonStyle
+  styleType?: ButtonStyleType
   size?: ButtonSize
-  iconType?: IconType
+  icon?: IconType
   children: string
 }
-type StyledButtonProps = StyledProps<ButtonProps, 'buttonStyle' | 'size'>
-type StyledIconProps = StyledProps<ButtonProps, 'buttonStyle'>
-type ApplyButtonColor = (theme: Theme, buttnStyle: ButtonStyle) => string
+type StyledButtonProps = StyledProps<ButtonProps, 'styleType' | 'size'>
+type StyledIconProps = StyledProps<ButtonProps, 'styleType'>
+type ApplyButtonColor = (theme: Theme, styleType: ButtonStyleType) => string
 type ApplyButtonSizeStyle = (
   theme: Theme,
-  buttnStyle: ButtonStyle,
+  styleType: ButtonStyleType,
   size: ButtonSize
 ) => string
 
@@ -41,14 +41,14 @@ const FONT_COLOR = {
 
 export const Button = ({
   size = 'medium',
-  buttonStyle = 'solidPrimary',
-  iconType,
+  styleType = 'solidPrimary',
+  icon,
   children,
   ...props
 }: ButtonProps): ReactElement => {
   return (
-    <StyledButton buttonStyle={buttonStyle} size={size} {...props}>
-      {iconType && <StyledIcon buttonStyle={buttonStyle} type={iconType} />}
+    <StyledButton size={size} styleType={styleType} {...props}>
+      {icon && <StyledIcon styleType={styleType} type={icon} />}
       {children}
     </StyledButton>
   )
@@ -60,19 +60,16 @@ const StyledButton = styled.button<StyledButtonProps>`
   align-items: center;
   border: none;
   cursor: pointer;
-  color: ${({ theme, buttonStyle }): string =>
-    applyButtonFontColor(theme, buttonStyle)};
+  color: ${({ theme, styleType: styleType }): string =>
+    applyButtonFontColor(theme, styleType)};
 
   ${({ theme }): string => theme.fonts.body02B}
-  ${({ theme, size, buttonStyle }): string =>
-    applyButtonSizeStyle(theme, buttonStyle, size)}
-  ${({ theme, buttonStyle }): string => applyButtonColor(theme, buttonStyle)}
+  ${({ theme, size, styleType: styleType }): string =>
+    applyButtonSizeStyle(theme, styleType, size)}
+  ${({ theme, styleType: styleType }): string =>
+    applyButtonColor(theme, styleType)}
 `
-const applyButtonSizeStyle: ApplyButtonSizeStyle = (
-  theme,
-  buttonStyle,
-  size
-) => {
+const applyButtonSizeStyle: ApplyButtonSizeStyle = (theme, styleType, size) => {
   const { round100, round4 } = theme.radius
 
   switch (size) {
@@ -82,9 +79,7 @@ const applyButtonSizeStyle: ApplyButtonSizeStyle = (
     case 'medium':
       return `width: 370px;
               height: 48px;
-              border-radius: ${
-                buttonStyle.indexOf('outline') >= 0 && round100
-              };`
+              border-radius: ${styleType.indexOf('outline') >= 0 && round100};`
     case 'small':
       return `display: inline-flex;
               height: 32px;
@@ -97,11 +92,11 @@ const applyButtonSizeStyle: ApplyButtonSizeStyle = (
 
 const StyledIcon = styled(Icon)<StyledIconProps>`
   margin-right: 4px;
-  color: ${({ theme, buttonStyle }): string =>
-    applyButtonFontColor(theme, buttonStyle)};
+  color: ${({ theme, styleType: styleType }): string =>
+    applyButtonFontColor(theme, styleType)};
 `
 
-const applyButtonColor: ApplyButtonColor = (theme, buttonStyle) => {
+const applyButtonColor: ApplyButtonColor = (theme, styleType) => {
   const { gray20, black, gray05, white } = theme.colors.grayScale
   const {
     SOLID_DISABLED,
@@ -112,7 +107,7 @@ const applyButtonColor: ApplyButtonColor = (theme, buttonStyle) => {
     GHOST
   } = BUTTON_STYLE_KEYS
 
-  switch (buttonStyle) {
+  switch (styleType) {
     case SOLID_DISABLED:
       return `background-color: ${gray20};`
     case SOLID_PRIMARY:
@@ -132,5 +127,5 @@ const applyButtonColor: ApplyButtonColor = (theme, buttonStyle) => {
   }
 }
 
-const applyButtonFontColor: ApplyButtonColor = (theme, buttonStyle) =>
-  theme.colors.grayScale[FONT_COLOR[buttonStyle]]
+const applyButtonFontColor: ApplyButtonColor = (theme, styleType) =>
+  theme.colors.grayScale[FONT_COLOR[styleType]]

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -60,14 +60,13 @@ const StyledButton = styled.button<StyledButtonProps>`
   align-items: center;
   border: none;
   cursor: pointer;
-  color: ${({ theme, styleType: styleType }): string =>
+  color: ${({ theme, styleType }): string =>
     applyButtonFontColor(theme, styleType)};
 
   ${({ theme }): string => theme.fonts.body02B}
-  ${({ theme, size, styleType: styleType }): string =>
+  ${({ theme, size, styleType }): string =>
     applyButtonSizeStyle(theme, styleType, size)}
-  ${({ theme, styleType: styleType }): string =>
-    applyButtonColor(theme, styleType)}
+  ${({ theme, styleType }): string => applyButtonColor(theme, styleType)}
 `
 const applyButtonSizeStyle: ApplyButtonSizeStyle = (theme, styleType, size) => {
   const { round100, round4 } = theme.radius
@@ -92,7 +91,7 @@ const applyButtonSizeStyle: ApplyButtonSizeStyle = (theme, styleType, size) => {
 
 const StyledIcon = styled(Icon)<StyledIconProps>`
   margin-right: 4px;
-  color: ${({ theme, styleType: styleType }): string =>
+  color: ${({ theme, styleType }): string =>
     applyButtonFontColor(theme, styleType)};
 `
 

--- a/src/components/ChattingBubble/ChattingBubble.stories.tsx
+++ b/src/components/ChattingBubble/ChattingBubble.stories.tsx
@@ -21,7 +21,7 @@ export const Default = Template.bind({})
 Default.args = {
   children:
     'Sender입니다. 대화대화대화 대화대화대화 대화대화대화 대화대화대화 대화대화대화 대화대화대화 대화대화대화 대화대화대화 대화대화대 문장으로 대화를 나눠볼까요? 최대 입력가능 문자수는 100자. 여기까지가 최대',
-  type: 'send'
+  messageType: 'send'
 }
 
 Default.parameters = {

--- a/src/components/ChattingBubble/index.tsx
+++ b/src/components/ChattingBubble/index.tsx
@@ -3,16 +3,16 @@ import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 
 export interface ChattingBubbleProps extends HTMLAttributes<HTMLDivElement> {
-  type: 'send' | 'receive'
+  messageType: 'send' | 'receive'
   children: string
 }
 
-type StyledBubbleProps = StyledProps<ChattingBubbleProps, 'type'> & {
+type StyledBubbleProps = StyledProps<ChattingBubbleProps, 'messageType'> & {
   isSend: boolean
 }
 
 export const ChattingBubble = ({
-  type,
+  messageType,
   children,
   ...props
 }: ChattingBubbleProps): ReactElement => {
@@ -20,11 +20,11 @@ export const ChattingBubble = ({
   const blankChatLength = children.length
   const noBlankChatLength = children.replace(newLineRegex, '').length
   const overChatLength = blankChatLength - noBlankChatLength
-  const isSend = type === 'send'
+  const isSend = messageType === 'send'
   const MAXIMUM_NUMBER_OF_CHATTINGBUBBLE = 100
 
   return (
-    <StyledBubble {...props} isSend={isSend} type={type}>
+    <StyledBubble {...props} isSend={isSend} messageType={messageType}>
       {noBlankChatLength <= MAXIMUM_NUMBER_OF_CHATTINGBUBBLE
         ? children
         : children?.substring(

--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -4,7 +4,7 @@ import type { DividerProps } from './index'
 
 export default {
   argTypes: {
-    orientation: {
+    direction: {
       control: { type: 'radio' },
       options: ['horizontal', 'vertical']
     },
@@ -20,6 +20,6 @@ export default {
 const Template: Story<DividerProps> = args => <Divider {...args} />
 export const Default = Template.bind({})
 Default.args = {
-  orientation: 'horizontal',
+  direction: 'horizontal',
   size: 'regular'
 }

--- a/src/components/Divider/index.tsx
+++ b/src/components/Divider/index.tsx
@@ -2,33 +2,33 @@ import type { HTMLAttributes, ReactElement } from 'react'
 import styled from '@emotion/styled'
 
 export interface DividerProps extends HTMLAttributes<HTMLDivElement> {
-  orientation?: 'vertical' | 'horizontal'
+  direction?: 'vertical' | 'horizontal'
   size?: 'bold' | 'regular'
 }
-type StyledDividerProps = Pick<DividerProps, 'orientation'>
+type StyledDividerProps = Pick<DividerProps, 'direction'>
 
 export const Divider = ({
-  orientation = 'horizontal',
+  direction = 'horizontal',
   size = 'regular',
   ...props
 }: DividerProps): ReactElement => {
   return (
-    <StyledDividerWrapper orientation={orientation} {...props}>
-      <StyledDivider orientation={orientation} size={size} />
+    <StyledDividerWrapper direction={direction} {...props}>
+      <StyledDivider direction={direction} size={size} />
     </StyledDividerWrapper>
   )
 }
 
 const StyledDividerWrapper = styled.div<StyledDividerProps>`
-  display: ${({ orientation }): string =>
-    orientation === 'horizontal' ? 'block' : 'inline-block'};
+  display: ${({ direction }): string =>
+    direction === 'horizontal' ? 'block' : 'inline-block'};
 `
 const StyledDivider = styled.hr<DividerProps>`
   margin: 0;
   padding: 0;
   width: 100%;
-  display: ${({ orientation }): string =>
-    orientation === 'horizontal' ? 'block' : 'inline'};
+  display: ${({ direction }): string =>
+    direction === 'horizontal' ? 'block' : 'inline'};
   border: ${({ theme, size }): string => {
     const { border, colors } = theme
 

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -11,7 +11,7 @@ const Template: Story<IconButtonProps> = args => <IconButton {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  color: 'primary',
+  colorType: 'primary',
   icon: 'arrowLeft',
   shape: 'rounded',
   size: 'small'

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 import type { Theme } from '@emotion/react'
 
-export type IconButtonColor =
+export type IconButtonColorType =
   | 'white'
   | 'black'
   | 'gray30'
@@ -19,7 +19,7 @@ type IconButtonShape = 'rounded' | 'square' | 'ghost'
 export interface IconButtonProps extends HTMLAttributes<HTMLButtonElement> {
   icon: IconType
   size?: IconButtonSize
-  colorType?: IconButtonColor
+  colorType?: IconButtonColorType
   hasShadow?: boolean
   shape?: IconButtonShape
 }
@@ -29,7 +29,7 @@ type StyledIconButtonProps = StyledProps<
   'size' | 'hasShadow' | 'shape' | 'colorType'
 >
 type StyledIconProps = StyledProps<StyledIconButtonProps, 'shape'> & {
-  colorType: IconButtonColor
+  colorType: IconButtonColorType
 }
 
 const ICON_BUTTON_SIZE = {
@@ -117,7 +117,7 @@ const StyledIcon = styled(Icon)<StyledIconProps>`
 `
 
 const applyIconButtonColor = (
-  colorType: IconButtonColor,
+  colorType: IconButtonColorType,
   theme: Theme
 ): string => {
   const { brand, grayScale } = theme.colors

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -19,14 +19,14 @@ type IconButtonShape = 'rounded' | 'square' | 'ghost'
 export interface IconButtonProps extends HTMLAttributes<HTMLButtonElement> {
   icon: IconType
   size?: IconButtonSize
-  color?: IconButtonColor
+  colorType?: IconButtonColor
   hasShadow?: boolean
   shape?: IconButtonShape
 }
 
 type StyledIconButtonProps = StyledProps<
   IconButtonProps,
-  'size' | 'hasShadow' | 'shape' | 'color'
+  'size' | 'hasShadow' | 'shape' | 'colorType'
 >
 type StyledIconProps = StyledProps<StyledIconButtonProps, 'shape'> & {
   colorType: IconButtonColor
@@ -48,7 +48,7 @@ const ICON_BUTTON_SIZE = {
 }
 
 export const IconButton = ({
-  color = 'black',
+  colorType = 'black',
   size = 'small',
   shape = 'ghost',
   hasShadow = false,
@@ -58,12 +58,12 @@ export const IconButton = ({
   return (
     <StyledIconButton
       {...props}
-      color={color}
+      colorType={colorType}
       hasShadow={hasShadow}
       shape={shape}
       size={size}>
       <StyledIcon
-        colorType={color}
+        colorType={colorType}
         shape={shape}
         size={ICON_BUTTON_SIZE[size].ICON}
         type={icon}
@@ -79,7 +79,7 @@ const StyledIconButton = styled.button<StyledIconButtonProps>`
   border: none;
   cursor: pointer;
 
-  ${({ size, theme, shape, hasShadow, color }): string => {
+  ${({ size, theme, shape, hasShadow, colorType }): string => {
     const isGhost = shape === 'ghost'
     const isRounded = shape === 'rounded'
 
@@ -87,7 +87,7 @@ const StyledIconButton = styled.button<StyledIconButtonProps>`
       width: ${ICON_BUTTON_SIZE[size].BUTTON}px;
       height: ${ICON_BUTTON_SIZE[size].BUTTON}px;
       background-color: ${
-        isGhost ? 'transparent' : applyIconButtonColor(color, theme)
+        isGhost ? 'transparent' : applyIconButtonColor(colorType, theme)
       };
       border-radius: ${isRounded ? theme.radius.round100 : 'none'};
       box-shadow: ${

--- a/src/components/ImageModal/index.tsx
+++ b/src/components/ImageModal/index.tsx
@@ -165,7 +165,7 @@ export const ImageModal = ({
       <StyledGradient direction="top" />
       <StyledGradient direction="bottom" />
       <StyledCloseIcon
-        color="gray30"
+        colorType="gray30"
         icon="close"
         size="medium"
         onClick={onClose}

--- a/src/components/ImageUploader/ImageUploader.stories.tsx
+++ b/src/components/ImageUploader/ImageUploader.stories.tsx
@@ -16,7 +16,7 @@ const Template: Story<ImageUploaderProps> = args => (
 )
 export const Default = Template.bind({})
 Default.args = {
-  imageList: [
+  images: [
     {
       id: uuidV4(),
       isRepresent: true,

--- a/src/components/ImageUploader/index.tsx
+++ b/src/components/ImageUploader/index.tsx
@@ -10,7 +10,7 @@ import { useImageUploader } from './useImageUploader'
 import { useMediaQuery } from '@hooks'
 
 export interface UploaderProps {
-  imageList: ImageInfo[]
+  images: ImageInfo[]
   uploaderRef: MutableRefObject<HTMLInputElement | null>
   imageListRef: MutableRefObject<HTMLDivElement | null>
   addImage: ChangeEventHandler<HTMLInputElement>
@@ -20,39 +20,39 @@ export interface UploaderProps {
 
 /* ImageUploader Props */
 export type ImageUploaderProps = {
-  imageList: ImageInfo[]
+  images: ImageInfo[]
   onChange: UploaderOnChangeHandler
 } & Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>
 
 const MAX_LIST_LENGTH = 10
 
 export const ImageUploader = ({
-  imageList: defaultImageList,
+  images: defaultImages,
   onChange,
   ...props
 }: ImageUploaderProps): ReactElement => {
   const {
     imageListRef,
     uploaderRef,
-    imageList,
+    images,
     openUploader,
     addImage,
     removeImage
   } = useImageUploader({
-    imageList: defaultImageList,
+    images: defaultImages,
     onChange
   })
   const isLessThanTablet = useMediaQuery('(max-width:1023px)')
   const Uploader = isLessThanTablet ? MobileUploader : DesktopUploader
-  const isShowListType = imageList.length > 0
-  const isMaximum = imageList.length === MAX_LIST_LENGTH
-  const imgTotal = `(${imageList.length}/${MAX_LIST_LENGTH})`
+  const isShowListType = images.length > 0
+  const isMaximum = images.length === MAX_LIST_LENGTH
+  const imgTotal = `(${images.length}/${MAX_LIST_LENGTH})`
 
   return (
     <Uploader
       addImage={addImage}
-      imageList={imageList}
       imageListRef={imageListRef}
+      images={images}
       imgTotal={imgTotal}
       isMaximum={isMaximum}
       isShowListType={isShowListType}

--- a/src/components/ImageUploader/uploader/DesktopUploader.tsx
+++ b/src/components/ImageUploader/uploader/DesktopUploader.tsx
@@ -60,7 +60,7 @@ export const DesktopUploader = ({
               onClick={(): void => {
                 removeImage(index)
               }}>
-              <Icon colorType={colors.grayScale.white} size={16} type="close" />
+              <Icon color={colors.grayScale.white} size={16} type="close" />
             </StyledRemoveButtonWrapper>
           </StyledImageItem>
         ))}

--- a/src/components/ImageUploader/uploader/DesktopUploader.tsx
+++ b/src/components/ImageUploader/uploader/DesktopUploader.tsx
@@ -19,7 +19,7 @@ type DesktopUploaderProps = {
 export const DesktopUploader = ({
   imageListRef,
   uploaderRef,
-  imageList,
+  images,
   openUploader,
   addImage,
   removeImage,
@@ -32,7 +32,7 @@ export const DesktopUploader = ({
     <StyledUploaderWrapper isShowListType={isShowListType} {...props}>
       <StyledTriggerWrapper onClick={openUploader}>
         <StyledTrigger isShowListType={isShowListType}>
-          <Icon colorType={colors.grayScale.gray30} size={40} type="picture" />
+          <Icon color={colors.grayScale.gray30} size={40} type="picture" />
           <StyledDescription>
             <p>상품 이미지 추가</p>
             <StyledImageTotal isMaximum={isMaximum}>
@@ -50,7 +50,7 @@ export const DesktopUploader = ({
         </StyledTrigger>
       </StyledTriggerWrapper>
       <StyledImageList ref={imageListRef}>
-        {imageList?.map(({ id, isRepresent, url }, index) => (
+        {images?.map(({ id, isRepresent, url }, index) => (
           <StyledImageItem key={id}>
             {isRepresent && (
               <StyledBadge colorType="orange">대표 사진</StyledBadge>

--- a/src/components/ImageUploader/uploader/DesktopUploader.tsx
+++ b/src/components/ImageUploader/uploader/DesktopUploader.tsx
@@ -52,9 +52,7 @@ export const DesktopUploader = ({
       <StyledImageList ref={imageListRef}>
         {imageList?.map(({ id, isRepresent, url }, index) => (
           <StyledImageItem key={id}>
-            {isRepresent && (
-              <StyledBadge colorScheme="orange">대표 사진</StyledBadge>
-            )}
+            {isRepresent && <StyledBadge colorType="orange">대표 사진</StyledBadge>}
             <Image alt={`file-${index}`} boxSize="280px" src={url} />
             <StyledRemoveButtonWrapper
               onClick={(): void => {

--- a/src/components/ImageUploader/uploader/MobileUploader.tsx
+++ b/src/components/ImageUploader/uploader/MobileUploader.tsx
@@ -31,7 +31,7 @@ export const MobileUploader = ({
   return (
     <StyledUploaderWrapper isShowListType={isShowListType} {...props}>
       <StyledTrigger onClick={openUploader}>
-        <Icon colorType={colors.grayScale.gray30} size={40} type="picture" />
+        <Icon color={colors.grayScale.gray30} size={40} type="picture" />
         <StyledImageTotal isMaximum={isMaximum}>{imgTotal}</StyledImageTotal>
         <StyledUploaderInput
           ref={uploaderRef}

--- a/src/components/ImageUploader/uploader/MobileUploader.tsx
+++ b/src/components/ImageUploader/uploader/MobileUploader.tsx
@@ -19,7 +19,7 @@ type MobileUploaderProps = {
 export const MobileUploader = ({
   imageListRef,
   uploaderRef,
-  imageList,
+  images,
   openUploader,
   addImage,
   removeImage,
@@ -42,7 +42,7 @@ export const MobileUploader = ({
         />
       </StyledTrigger>
       <StyledImageList ref={imageListRef}>
-        {imageList?.map(({ id, isRepresent, url }, index) => (
+        {images?.map(({ id, isRepresent, url }, index) => (
           <StyledImageItem key={id}>
             {isRepresent && (
               <StyledBadge colorType="orange">대표 사진</StyledBadge>
@@ -52,7 +52,7 @@ export const MobileUploader = ({
               onClick={(): void => {
                 removeImage(index)
               }}>
-              <Icon colorType={colors.grayScale.white} size={16} type="close" />
+              <Icon color={colors.grayScale.white} size={16} type="close" />
             </StyledRemoveButtonWrapper>
           </StyledImageItem>
         ))}

--- a/src/components/ImageUploader/uploader/MobileUploader.tsx
+++ b/src/components/ImageUploader/uploader/MobileUploader.tsx
@@ -44,9 +44,7 @@ export const MobileUploader = ({
       <StyledImageList ref={imageListRef}>
         {imageList?.map(({ id, isRepresent, url }, index) => (
           <StyledImageItem key={id}>
-            {isRepresent && (
-              <StyledBadge colorScheme="orange">대표 사진</StyledBadge>
-            )}
+            {isRepresent && <StyledBadge colorType="orange">대표 사진</StyledBadge>}
             <Image alt={`file-${index}`} boxSize="80px" src={url} />
             <StyledRemoveButtonWrapper
               onClick={(): void => {

--- a/src/components/ImageUploader/useImageUploader.ts
+++ b/src/components/ImageUploader/useImageUploader.ts
@@ -11,15 +11,15 @@ const isValidImageUrl = (file: unknown): file is string =>
 const MAX_LIST_LENGTH = 10
 
 export const useImageUploader = ({
-  imageList: defaultImageList,
+  images: defaultImages,
   onChange
 }: ImageUploaderProps): UploaderProps => {
   const uploaderRef = useRef<HTMLInputElement | null>(null)
   const imageListRef = useRef<HTMLDivElement | null>(null)
-  const [imageList, setImageList] = useState<ImageInfo[]>(defaultImageList)
+  const [images, setImages] = useState<ImageInfo[]>(defaultImages)
 
   const openUploader = (): void => {
-    if (imageList.length === MAX_LIST_LENGTH) {
+    if (images.length === MAX_LIST_LENGTH) {
       alert(NOTICE_MESSAGE.IMAGE_UPLOAD)
       return
     }
@@ -32,16 +32,16 @@ export const useImageUploader = ({
       return
     }
 
-    const newFiles = [...imageList]
+    const newFiles = [...images]
     newFiles.splice(index, 1)
 
-    const isRepresent = imageList[index].isRepresent && imageList.length > 1
+    const isRepresent = images[index].isRepresent && images.length > 1
     if (isRepresent) {
       newFiles[0].isRepresent = true
     }
 
     onChange({ eventType: 'remove', imageList: newFiles })
-    setImageList(newFiles)
+    setImages(newFiles)
   }
 
   const addImage: ChangeEventHandler<HTMLInputElement> = async e => {
@@ -52,7 +52,7 @@ export const useImageUploader = ({
     }
 
     const isOverListLength =
-      MAX_LIST_LENGTH - (imageList.length + files.length) < 0
+      MAX_LIST_LENGTH - (images.length + files.length) < 0
     if (isOverListLength) {
       alert(NOTICE_MESSAGE.IMAGE_UPLOAD)
       return
@@ -72,7 +72,7 @@ export const useImageUploader = ({
 
     const imageFiles = await Promise.all(fulfilledImageFiles)
     const newImageList = imageFiles.map((file, index) => {
-      const isRepresent = imageList.length === 0 && index === 0
+      const isRepresent = images.length === 0 && index === 0
       const imageUrl = isValidImageUrl(file) ? file : ''
 
       return {
@@ -82,15 +82,15 @@ export const useImageUploader = ({
       }
     })
 
-    setImageList(prevImageList => [...prevImageList, ...newImageList])
-    onChange({ eventType: 'upload', imageList })
+    setImages(prevImageList => [...prevImageList, ...newImageList])
+    onChange({ eventType: 'upload', imageList: images })
     e.target.value = ''
   }
 
   return {
     addImage,
-    imageList,
     imageListRef,
+    images,
     openUploader,
     removeImage,
     uploaderRef

--- a/src/components/ImageUploader/useImageUploader.ts
+++ b/src/components/ImageUploader/useImageUploader.ts
@@ -32,16 +32,16 @@ export const useImageUploader = ({
       return
     }
 
-    const newFiles = [...images]
-    newFiles.splice(index, 1)
+    const newImages = [...images]
+    newImages.splice(index, 1)
 
     const isRepresent = images[index].isRepresent && images.length > 1
     if (isRepresent) {
-      newFiles[0].isRepresent = true
+      newImages[0].isRepresent = true
     }
 
-    onChange({ eventType: 'remove', imageList: newFiles })
-    setImages(newFiles)
+    onChange({ eventType: 'remove', images: newImages })
+    setImages(newImages)
   }
 
   const addImage: ChangeEventHandler<HTMLInputElement> = async e => {
@@ -71,7 +71,7 @@ export const useImageUploader = ({
     })
 
     const imageFiles = await Promise.all(fulfilledImageFiles)
-    const newImageList = imageFiles.map((file, index) => {
+    const newImages = imageFiles.map((file, index) => {
       const isRepresent = images.length === 0 && index === 0
       const imageUrl = isValidImageUrl(file) ? file : ''
 
@@ -82,8 +82,8 @@ export const useImageUploader = ({
       }
     })
 
-    setImages(prevImageList => [...prevImageList, ...newImageList])
-    onChange({ eventType: 'upload', imageList: images })
+    setImages(prevImageList => [...prevImageList, ...newImages])
+    onChange({ eventType: 'upload', images })
     e.target.value = ''
   }
 

--- a/src/components/Input/ChattingInput.tsx
+++ b/src/components/Input/ChattingInput.tsx
@@ -32,7 +32,7 @@ export const ChattingInput = ({
     <StyledInputForm>
       <StyledInput isSmall={isSmall} onChange={handleChange} {...props} />
       <StyledIconButton
-        color={isDisabled ? 'primaryWeak' : 'primary'}
+        colorType={isDisabled ? 'primaryWeak' : 'primary'}
         disabled={isDisabled}
         icon="arrowUp"
         isSmall={isSmall}

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -8,16 +8,16 @@ export default {
       control: 'radio',
       options: ['small', 'large']
     },
-    inputStyle: {
-      control: 'radio',
-      options: Object.values(INPUT_STYLE_KEYS)
-    },
     isPrice: {
       control: 'boolean'
     },
     status: {
       control: 'radio',
       options: ['error', 'success', 'default', 'none']
+    },
+    styleType: {
+      control: 'radio',
+      options: Object.values(INPUT_STYLE_KEYS)
     }
   },
   components: Input,
@@ -30,9 +30,9 @@ export const Default = Template.bind({})
 Default.args = {
   guideMessage: '안내 메세지',
   inputSize: 'large',
-  inputStyle: 'default',
   isPrice: true,
   label: '라벨',
   placeholder: '내용을 입력하세요',
-  status: 'success'
+  status: 'success',
+  styleType: 'default'
 }

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -4,10 +4,10 @@ import { DefaultInput } from './DefaultInput'
 import { EditInput } from './EditInput'
 import { SearchInput } from './SearchInput'
 
-type InputStyle = typeof INPUT_STYLE_KEYS[keyof typeof INPUT_STYLE_KEYS]
+type InputStyleType = typeof INPUT_STYLE_KEYS[keyof typeof INPUT_STYLE_KEYS]
 export type InputSize = 'large' | 'small'
 export interface InputProps extends HTMLAttributes<HTMLInputElement> {
-  inputStyle?: InputStyle
+  styleType?: InputStyleType
   inputSize?: InputSize
   label?: string
   status?: 'none' | 'success' | 'error' | 'default'
@@ -26,16 +26,16 @@ export const INPUT_STYLE_KEYS = {
 } as const
 
 export const Input = ({
-  inputStyle = 'default',
+  styleType = 'default',
   inputSize = 'small',
   ...props
 }: InputProps): ReactElement => {
-  const renderInput = (inputStyle: InputStyle): ReactElement => {
+  const renderInput = (styleType: InputStyleType): ReactElement => {
     const { EDIT, DEFAULT, CHATTING, SEARCH } = INPUT_STYLE_KEYS
     const isSmall = inputSize === 'small'
     const inputTypeProps = { isSmall, ...props }
 
-    switch (inputStyle) {
+    switch (styleType) {
       case DEFAULT:
         return <DefaultInput {...inputTypeProps} />
       case CHATTING:
@@ -49,5 +49,5 @@ export const Input = ({
     }
   }
 
-  return renderInput(inputStyle)
+  return renderInput(styleType)
 }

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -42,7 +42,7 @@ export const Modal = ({
     <StyledDIM isOpen={isOpen}>
       <StyledModal {...props} ref={modalRef} height={height} width={width}>
         <StyledCloseIcon
-          color="gray30"
+          colorType="gray30"
           icon="close"
           shape="ghost"
           onClick={onClose}

--- a/src/components/SelectBox/SelectBox.stories.tsx
+++ b/src/components/SelectBox/SelectBox.stories.tsx
@@ -5,7 +5,7 @@ import type { SelectBoxProps } from './index'
 
 export default {
   argTypes: {
-    colorScheme: {
+    colorType: {
       control: 'radio',
       options: ['none', 'light', 'dark']
     },
@@ -21,7 +21,7 @@ export default {
 const Template: Story<SelectBoxProps> = args => <SelectBox {...args} />
 export const Default = Template.bind({})
 Default.args = {
-  colorScheme: 'light',
+  colorType: 'light',
   items: [
     {
       text: '선택1',

--- a/src/components/SelectBox/SelectBox.stories.tsx
+++ b/src/components/SelectBox/SelectBox.stories.tsx
@@ -22,10 +22,7 @@ const Template: Story<SelectBoxProps> = args => <SelectBox {...args} />
 export const Default = Template.bind({})
 Default.args = {
   colorScheme: 'light',
-  onChange: (options): void => {
-    action(JSON.stringify(options))
-  },
-  options: [
+  items: [
     {
       text: '선택1',
       value: 'select1'
@@ -35,5 +32,8 @@ Default.args = {
       value: 'select2'
     }
   ],
+  onChange: (options): void => {
+    action(JSON.stringify(options))
+  },
   size: 'small'
 }

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -7,14 +7,14 @@ import type { Theme } from '@emotion/react'
 import { useClose } from '@hooks'
 import { useState } from 'react'
 
-type ColorType = 'none' | 'light' | 'dark'
+type SelectColorType = 'none' | 'light' | 'dark'
 type Size = 'small' | 'medium'
 interface Item {
   text: string
   value: string | number
 }
 export type SelectBoxProps = {
-  colorType?: ColorType
+  colorType?: SelectColorType
   size?: Size
   placeholder?: string
   value: string | number
@@ -32,7 +32,7 @@ type GetFontColorParams = Omit<StyledSelectProps, 'isSelected'> & {
   theme: Theme
 }
 type GetFontColor = (params: GetFontColorParams) => string
-type ApplyColorScheme = (colorType: ColorType, theme: Theme) => string
+type ApplyColorScheme = (colorType: SelectColorType, theme: Theme) => string
 type ApplySize = (size: Size, theme: Theme) => string
 
 export const SelectBox = ({
@@ -107,7 +107,7 @@ const StyledSelectBoxWrapper = styled.div`
 
 /** Trigger */
 const StyledTriggerWrapper = styled.div<Omit<StyledSelectProps, 'isSelected'>>`
-  ${({ colorType: colorType, isEmpty, theme, size }): string => `
+  ${({ colorType, isEmpty, theme, size }): string => `
     display: inline-flex;
     flex-direction: row;
     justify-content: space-between;
@@ -116,7 +116,7 @@ const StyledTriggerWrapper = styled.div<Omit<StyledSelectProps, 'isSelected'>>`
     cursor: pointer;
     ${applyColorScheme(colorType, theme)}
     ${applySize(size, theme)}
-    color:${getFontColor({ colorType: colorType, isEmpty, size, theme })};
+    color:${getFontColor({ colorType, isEmpty, size, theme })};
   `}
 `
 const StyledTriggerArrow = styled(Icon)`
@@ -212,12 +212,7 @@ const applyColorScheme: ApplyColorScheme = (colorType, theme) => {
       `
   }
 }
-const getFontColor: GetFontColor = ({
-  isEmpty,
-  colorType: colorType,
-  size,
-  theme
-}) => {
+const getFontColor: GetFontColor = ({ isEmpty, colorType, size, theme }) => {
   const { gray50, gray90, black, white } = theme.colors.grayScale
   const isDark = colorType === 'dark'
   const smallPrimary = isDark ? white : gray90

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react'
 
 type ColorScheme = 'none' | 'light' | 'dark'
 type Size = 'small' | 'medium'
-interface Option {
+interface Item {
   text: string
   value: string | number
 }
@@ -18,7 +18,7 @@ export type SelectBoxProps = {
   size?: Size
   placeholder?: string
   value: string | number
-  options: Option[]
+  items: Item[]
   onChange: SelectOnChangeHandler
 } & Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>
 
@@ -40,15 +40,14 @@ export const SelectBox = ({
   size = 'small',
   placeholder = '값을 입력하세요.',
   value: defaultValue = '',
-  options,
+  items,
   onChange,
   ...props
 }: SelectBoxProps): ReactElement => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [value, setValue] = useState<number | string>(defaultValue)
   const ref = useClose<HTMLDivElement>({ onClose: setIsOpen })
-  const text =
-    options.find(option => option.value === value)?.text || placeholder
+  const text = items.find(option => option.value === value)?.text || placeholder
   const isEmpty = value === ''
 
   const handleOpenOptions = (): void => {
@@ -85,7 +84,7 @@ export const SelectBox = ({
       {isOpen && (
         <StyledOptionListWrapper size={size}>
           <StyledOptionList>
-            {options?.map(item => (
+            {items?.map(item => (
               <StyledOptionsWrapper
                 key={item.value}
                 isSelected={value === item.value}

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -7,14 +7,14 @@ import type { Theme } from '@emotion/react'
 import { useClose } from '@hooks'
 import { useState } from 'react'
 
-type ColorScheme = 'none' | 'light' | 'dark'
+type ColorType = 'none' | 'light' | 'dark'
 type Size = 'small' | 'medium'
 interface Item {
   text: string
   value: string | number
 }
 export type SelectBoxProps = {
-  colorScheme?: ColorScheme
+  colorType?: ColorType
   size?: Size
   placeholder?: string
   value: string | number
@@ -24,7 +24,7 @@ export type SelectBoxProps = {
 
 /** Styled Type */
 interface StyledSelectProps
-  extends StyledProps<SelectBoxProps, 'colorScheme' | 'size'> {
+  extends StyledProps<SelectBoxProps, 'colorType' | 'size'> {
   isEmpty: boolean
   isSelected: boolean
 }
@@ -32,11 +32,11 @@ type GetFontColorParams = Omit<StyledSelectProps, 'isSelected'> & {
   theme: Theme
 }
 type GetFontColor = (params: GetFontColorParams) => string
-type ApplyColorScheme = (colorScheme: ColorScheme, theme: Theme) => string
+type ApplyColorScheme = (colorType: ColorType, theme: Theme) => string
 type ApplySize = (size: Size, theme: Theme) => string
 
 export const SelectBox = ({
-  colorScheme = 'light',
+  colorType = 'light',
   size = 'small',
   placeholder = '값을 입력하세요.',
   value: defaultValue = '',
@@ -62,7 +62,7 @@ export const SelectBox = ({
 
   const getIconColor = (): string => {
     const { gray90, white } = colors.grayScale
-    const isDark = colorScheme === 'dark'
+    const isDark = colorType === 'dark'
 
     return isDark ? white : gray90
   }
@@ -70,7 +70,7 @@ export const SelectBox = ({
   return (
     <StyledSelectBoxWrapper ref={ref} {...props}>
       <StyledTriggerWrapper
-        colorScheme={colorScheme}
+        colorType={colorType}
         isEmpty={isEmpty}
         size={size}
         onClick={handleOpenOptions}>
@@ -107,16 +107,16 @@ const StyledSelectBoxWrapper = styled.div`
 
 /** Trigger */
 const StyledTriggerWrapper = styled.div<Omit<StyledSelectProps, 'isSelected'>>`
-  ${({ colorScheme, isEmpty, theme, size }): string => `
+  ${({ colorType: colorType, isEmpty, theme, size }): string => `
     display: inline-flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
     position: relative;
     cursor: pointer;
-    ${applyColorScheme(colorScheme, theme)}
+    ${applyColorScheme(colorType, theme)}
     ${applySize(size, theme)}
-    color:${getFontColor({ colorScheme, isEmpty, size, theme })};
+    color:${getFontColor({ colorType: colorType, isEmpty, size, theme })};
   `}
 `
 const StyledTriggerArrow = styled(Icon)`
@@ -191,10 +191,10 @@ const applySize: ApplySize = (size, theme) => {
       `
   }
 }
-const applyColorScheme: ApplyColorScheme = (colorScheme, theme) => {
+const applyColorScheme: ApplyColorScheme = (colorType, theme) => {
   const { black, gray20, white } = theme.colors.grayScale
 
-  switch (colorScheme) {
+  switch (colorType) {
     case 'none':
       return `
         background-color: none;
@@ -212,9 +212,14 @@ const applyColorScheme: ApplyColorScheme = (colorScheme, theme) => {
       `
   }
 }
-const getFontColor: GetFontColor = ({ isEmpty, colorScheme, size, theme }) => {
+const getFontColor: GetFontColor = ({
+  isEmpty,
+  colorType: colorType,
+  size,
+  theme
+}) => {
   const { gray50, gray90, black, white } = theme.colors.grayScale
-  const isDark = colorScheme === 'dark'
+  const isDark = colorType === 'dark'
   const smallPrimary = isDark ? white : gray90
   const mediumPrimary = isDark ? white : black
 

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -8,13 +8,13 @@ export default {
     color: {
       control: { type: 'color' }
     },
+    styleType: {
+      control: { type: 'select' },
+      options: [...Object.keys(fonts)]
+    },
     tag: {
       control: { type: 'radio' },
       options: ['p', 'span']
-    },
-    textStyle: {
-      control: { type: 'select' },
-      options: [...Object.keys(fonts)]
     }
   },
   component: Text,
@@ -26,5 +26,5 @@ const Template: Story<TextProps> = args => <Text {...args} />
 export const Default = Template.bind({})
 Default.args = {
   children: 'hello',
-  textStyle: 'body01M'
+  styleType: 'body01M'
 }

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -4,22 +4,22 @@ import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 
 export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
-  textStyle: FontStyleKeys
+  styleType: FontStyleKeys
   tag?: 'p' | 'span'
   children: string
   color?: string
 }
 
-type StyledTextProps = StyledProps<TextProps, 'textStyle' | 'color'>
+type StyledTextProps = StyledProps<TextProps, 'styleType' | 'color'>
 
 export const Text = ({
   tag = 'span',
   children,
-  textStyle = 'body01M',
+  styleType: textStyle = 'body01M',
   color = 'black'
 }: TextProps): ReactElement => {
   return (
-    <StyledText as={tag} color={color} textStyle={textStyle}>
+    <StyledText as={tag} color={color} styleType={textStyle}>
       {children}
     </StyledText>
   )
@@ -28,5 +28,5 @@ export const Text = ({
 const StyledText = styled.span<StyledTextProps>`
   color: ${({ color }): string => color};
 
-  ${({ theme, textStyle }): string => theme.fonts[textStyle]};
+  ${({ theme, styleType }): string => theme.fonts[styleType]};
 `

--- a/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -11,10 +11,10 @@ const Template: Story<ToggleButtonProps> = args => <ToggleButton {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  color: 'gray30',
+  colorType: 'gray30',
   icon: 'heart',
   shape: 'rounded',
   size: 'medium',
-  toggleColor: 'primary',
+  toggleColorType: 'primary',
   type: 'fill'
 }

--- a/src/components/ToggleButton/index.tsx
+++ b/src/components/ToggleButton/index.tsx
@@ -46,7 +46,7 @@ export const ToggleButton = ({
 
   return (
     <IconButton
-      color={renderIcon.color}
+      colorType={renderIcon.color}
       icon={renderIcon.icon as IconType}
       onClick={handleClick}
       {...props}

--- a/src/components/ToggleButton/index.tsx
+++ b/src/components/ToggleButton/index.tsx
@@ -1,4 +1,8 @@
-import type { IconButtonColor, IconButtonProps, IconType } from '@components'
+import type {
+  IconButtonColorType,
+  IconButtonProps,
+  IconType
+} from '@components'
 import type { MouseEventHandler, ReactElement } from 'react'
 import { IconButton } from '@components'
 import { useState } from 'react'
@@ -16,8 +20,8 @@ interface StrokeToggleButton {
   icon: IconType
 }
 export type ToggleButtonProps = IconButtonProps & {
-  color?: IconButtonColor
-  toggleColor?: IconButtonColor
+  colorType?: IconButtonColorType
+  toggleColorType?: IconButtonColorType
 } & ToggleButtonType
 
 type ToggleButtonType = FillToggleButton | StrokeToggleButton
@@ -25,8 +29,8 @@ type ToggleButtonType = FillToggleButton | StrokeToggleButton
 export const ToggleButton = ({
   onClick,
   type = 'stroke',
-  color = 'black',
-  toggleColor = color,
+  colorType = 'black',
+  toggleColorType = colorType,
   icon,
   ...props
 }: ToggleButtonProps): ReactElement => {
@@ -34,7 +38,7 @@ export const ToggleButton = ({
   const isFillType = type === 'fill'
   const toggleIcon = isFillType ? `${icon}Fill` : icon
   const renderIcon = {
-    color: isToggle ? toggleColor : color,
+    color: isToggle ? toggleColorType : colorType,
     icon: isToggle ? toggleIcon : icon
   }
 

--- a/src/types/offer.d.ts
+++ b/src/types/offer.d.ts
@@ -1,9 +1,9 @@
 /** SelectBox  */
-interface SelectOptions {
+interface SelectItem {
   text: string
   value: string | number
 }
-export declare type SelectOnChangeHandler = (item: SelectOptions) => void
+export declare type SelectOnChangeHandler = (item: SelectItem) => void
 
 /**  ImageUploader */
 export interface ImageInfo {

--- a/src/types/offer.d.ts
+++ b/src/types/offer.d.ts
@@ -13,7 +13,7 @@ export interface ImageInfo {
 }
 interface ImageUploaderParams {
   eventType: 'upload' | 'remove'
-  imageList: ImageInfo[]
+  images: ImageInfo[]
 }
 export declare type UploaderOnChangeHandler = (
   params: ImageUploaderParams


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #69 

## ⛳ 구현 사항
- props명 통일과 Button 컴포넌트 오타를 수정하였습니다.

## 📚 구현 설명
- styleType → 색상 및 형태 변경
- color → 색상 변경 (hexcolor)
- colorType 색상 변경 (내부 지정된 string)

## Badge

- ~~colorScheme~~ → colorType

## Divider

- ~~orientation~~ → direction

## ImageUploader

- ~~imageList~~ → images

## SelectBox

- ~~colorScheme~~ → colorType
- ~~options~~ → items

## ChattingBubble

- ~~type~~ → messageType

## Radio

- ~~formName~~ → name

## Text

- ~~textStyle~~ → styleType

## Button

- ~~buttonStyle~~ → styleType
- ~~iconType~~ → icon

## IconButton

- ~~color~~ → colorType

## ToggleButton

- ~~color~~ → colorType
- ~~toggleColor~~ → toggleColorType

## Input

- ~~inputStyle~~ → styleType

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->