### PR TITLE
docs: 타입 설명 jsdoc 추가(Icon, IconButton, ToggleButton, ImageModal, Modal, Text, Button, Input)

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -8,9 +8,28 @@ import type { Theme } from '@emotion/react'
 type ButtonStyleType = typeof BUTTON_STYLE_KEYS[keyof typeof BUTTON_STYLE_KEYS]
 type ButtonSize = 'small' | 'medium' | 'large'
 export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
+  /**
+   * Button의 스타일을 정합니다.
+   * @type "ghost" | "outline" | "outlineDisabled" | "solidDisabled" | "solidPrimary" | "solidSub" | undefined
+   */
   styleType?: ButtonStyleType
+
+  /**
+   * Button의 사이즈 속성을 정합니다.
+   * @type 'small' | 'medium' | 'large' | undefined
+   */
   size?: ButtonSize
+
+  /**
+   * Button에 포함될 아이콘 타입을 정합니다.
+   * @type IconType | undefined
+   */
   icon?: IconType
+
+  /**
+   * Button 내부에 작성할 문자열을 정합니다.
+   * @type string
+   */
   children: string
 }
 type StyledButtonProps = StyledProps<ButtonProps, 'styleType' | 'size'>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -9,13 +9,13 @@ type ButtonStyleType = typeof BUTTON_STYLE_KEYS[keyof typeof BUTTON_STYLE_KEYS]
 type ButtonSize = 'small' | 'medium' | 'large'
 export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
   /**
-   * Button의 스타일을 정합니다.
+   * Button의 보여질 형태를 정합니다.
    * @type "ghost" | "outline" | "outlineDisabled" | "solidDisabled" | "solidPrimary" | "solidSub" | undefined
    */
   styleType?: ButtonStyleType
 
   /**
-   * Button의 사이즈 속성을 정합니다.
+   * Button의 크기를 정합니다.
    * @type 'small' | 'medium' | 'large' | undefined
    */
   size?: ButtonSize

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -39,8 +39,22 @@ import type { StyledProps } from '@types'
 
 export type IconType = keyof typeof ICON_TYPES
 export interface IconProps extends HTMLAttributes<HTMLOrSVGElement> {
+  /**
+   * Icon의 사이즈를 정합니다.
+   * @type number | undefined
+   */
   size?: number
+
+  /**
+   * Icon의 색상을 정합니다.
+   * @type string | undefined
+   */
   color?: string
+
+  /**
+   * Icon의 타입을 정합니다.
+   * @type IconType
+   */
   type: IconType
 }
 

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -40,7 +40,7 @@ import type { StyledProps } from '@types'
 export type IconType = keyof typeof ICON_TYPES
 export interface IconProps extends HTMLAttributes<HTMLOrSVGElement> {
   /**
-   * Icon의 사이즈를 정합니다.
+   * Icon의 크기를 정합니다.
    * @type number | undefined
    */
   size?: number

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -24,7 +24,7 @@ export interface IconButtonProps extends HTMLAttributes<HTMLButtonElement> {
   icon: IconType
 
   /**
-   * IconButton의 사이즈를 정합니다.
+   * IconButton의 크기를 정합니다.
    * @type 'small' | 'medium' | 'large' | undefined
    */
   size?: IconButtonSize
@@ -36,7 +36,7 @@ export interface IconButtonProps extends HTMLAttributes<HTMLButtonElement> {
   colorType?: IconButtonColorType
 
   /**
-   * IconButton가 그림자를 가질지 정합니다.
+   * IconButton가 그림자 여부를 정합니다.
    * @type boolean | undefined
    */
   hasShadow?: boolean

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -17,10 +17,34 @@ type IconButtonSize = 'small' | 'medium' | 'large'
 type IconButtonShape = 'rounded' | 'square' | 'ghost'
 
 export interface IconButtonProps extends HTMLAttributes<HTMLButtonElement> {
+  /**
+   * IconButton으로 사용될 아이콘의 타입을 정합니다.
+   * @type IconType
+   */
   icon: IconType
+
+  /**
+   * IconButton의 사이즈를 정합니다.
+   * @type 'small' | 'medium' | 'large' | undefined
+   */
   size?: IconButtonSize
+
+  /**
+   * IconButton의 색상 타입을 정합니다.
+   * @type 'white' | 'black' | 'gray30' | 'primary' | 'primaryWeak' | 'sub' | 'subWeak' | undefined
+   */
   colorType?: IconButtonColorType
+
+  /**
+   * IconButton가 그림자를 가질지 정합니다.
+   * @type boolean | undefined
+   */
   hasShadow?: boolean
+
+  /**
+   * IconButton의 모양을 지정합니다.
+   * @type 'rounded' | 'square' | 'ghost' | undefined
+   */
   shape?: IconButtonShape
 }
 

--- a/src/components/ImageModal/index.tsx
+++ b/src/components/ImageModal/index.tsx
@@ -10,9 +10,28 @@ interface ImageInfo {
   id: string
 }
 export interface ImageModalProps extends HTMLAttributes<HTMLDivElement> {
-  isOpen?: boolean
+  /**
+   * ImageModal의 open/close 상태를 정합니다.
+   * @type boolean | undefined
+   */
+  isOpen?: boolean | undefined
+
+  /**
+   * ImageModal에 띄울 이미지들을 정합니다.
+   * @type IconType
+   */
   images: ImageInfo[]
+
+  /**
+   * ImageModal의 이름을 정합니다.
+   * @type string
+   */
   name: string
+
+  /**
+   * ImageModal이 close될 때 실행할 함수를 정합니다.
+   * @type (): void | undefined
+   */
   onClose?(): void
 }
 type ResizeImageInfo = ImageInfo & {

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -7,11 +7,40 @@ import { SearchInput } from './SearchInput'
 type InputStyleType = typeof INPUT_STYLE_KEYS[keyof typeof INPUT_STYLE_KEYS]
 export type InputSize = 'large' | 'small'
 export interface InputProps extends HTMLAttributes<HTMLInputElement> {
+  /**
+   * Input의 스타일 타입을 정합니다.
+   * @type "chatting" | "default" | "edit" | "search" | undefined
+   */
   styleType?: InputStyleType
+
+  /**
+   * Input의 사이즈를 정합니다.
+   * @type 'large' | 'small' | undefined
+   */
   inputSize?: InputSize
+
+  /**
+   * Input의 label 메세지를 정합니다.
+   * @type string | undefined
+   */
   label?: string
+
+  /**
+   * Input의 추가 설명 메세지의 상태를 정합니다.
+   * @type 'none' | 'success' | 'error' | 'default' | undefined
+   */
   status?: 'none' | 'success' | 'error' | 'default'
+
+  /**
+   * Input의 설명 메세지를 정합니다.
+   * @type string | undefined
+   */
   guideMessage?: string
+
+  /**
+   * Input 값으로 가격을 받는지 여부를 정합니다.
+   * @type boolean | undefined
+   */
   isPrice?: boolean
 }
 export type MainInputProps = Omit<InputProps, 'inputSize'> & {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -7,10 +7,34 @@ import type { StyledProps } from '@types'
 import { useClickAway } from '@hooks'
 
 export interface ModalProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Modal 내부에 들어갈 내용을 정합니다.
+   * @type ReactElement
+   */
   children: ReactElement
+
+  /**
+   * Modal의 open/close 여부를 정합니다.
+   * @type boolean | undefined
+   */
   isOpen?: boolean
-  width?: number
+
+  /**
+   * Modal의 너비를 정합니다.
+   * @type number
+   */
+  width?: number | undefined
+
+  /**
+   * Modal의 높이를 정합니다.
+   * @type number | undefined
+   */
   height?: number
+
+  /**
+   * Modal이 close될 때 실행할 함수를 정합니다.
+   * @type (): void | undefined
+   */
   onClose?(): void
 }
 

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -4,9 +4,28 @@ import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 
 export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Text의 스타일을 정합니다.
+   * @type FontStyleKeys
+   */
   styleType: FontStyleKeys
+
+  /**
+   * Text의 태그를 정합니다.
+   * @type 'p' | 'span' | undefined
+   */
   tag?: 'p' | 'span'
+
+  /**
+   * Text로 작성할 문자열을 정합니다.
+   * @type string
+   */
   children: string
+
+  /**
+   * Text의 색상을 정합니다.
+   * @type string | undefined
+   */
   color?: string
 }
 

--- a/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -15,6 +15,6 @@ Default.args = {
   icon: 'heart',
   shape: 'rounded',
   size: 'medium',
-  toggleColorType: 'primary',
-  type: 'fill'
+  styleType: 'fill',
+  toggleColorType: 'primary'
 }

--- a/src/components/ToggleButton/index.tsx
+++ b/src/components/ToggleButton/index.tsx
@@ -16,10 +16,10 @@ interface FillToggleButton {
    * ToggleButton의 스타일 타입을 정합니다.
    * @type 'fill'
    */
-  type: 'fill'
+  styleType: 'fill'
 
   /**
-   * ToggleButton의 type이 'fill'인 경우 사용 가능한 아이콘 타입을 정합니다.
+   * ToggleButton의 styleType이 'fill'인 경우 사용 가능한 아이콘 타입을 정합니다.
    * @type "checkCircle" | "heart" | "meh" | "sad" | "smile" | undefined
    */
   icon: FillIconType
@@ -29,7 +29,7 @@ interface StrokeToggleButton {
    * ToggleButton으로 아이콘의 타입을 정합니다.
    * @type 'stroke'
    */
-  type: 'stroke'
+  styleType: 'stroke'
 
   /**
    * ToggleButton.
@@ -55,14 +55,14 @@ type ToggleButtonType = FillToggleButton | StrokeToggleButton
 
 export const ToggleButton = ({
   onClick,
-  type = 'stroke',
+  styleType = 'stroke',
   colorType = 'black',
   toggleColorType = colorType,
   icon,
   ...props
 }: ToggleButtonProps): ReactElement => {
   const [isToggle, setIsToggle] = useState<boolean>(false)
-  const isFillType = type === 'fill'
+  const isFillType = styleType === 'fill'
   const toggleIcon = isFillType ? `${icon}Fill` : icon
   const renderIcon = {
     color: isToggle ? toggleColorType : colorType,

--- a/src/components/ToggleButton/index.tsx
+++ b/src/components/ToggleButton/index.tsx
@@ -12,15 +12,42 @@ type FillIconType = Extract<
   'checkCircle' | 'heart' | 'meh' | 'sad' | 'smile'
 >
 interface FillToggleButton {
+  /**
+   * ToggleButton의 스타일 타입을 정합니다.
+   * @type 'fill'
+   */
   type: 'fill'
+
+  /**
+   * ToggleButton의 type이 'fill'인 경우 사용 가능한 아이콘 타입을 정합니다.
+   * @type "checkCircle" | "heart" | "meh" | "sad" | "smile" | undefined
+   */
   icon: FillIconType
 }
 interface StrokeToggleButton {
+  /**
+   * ToggleButton으로 아이콘의 타입을 정합니다.
+   * @type 'stroke'
+   */
   type: 'stroke'
+
+  /**
+   * ToggleButton.
+   * @type IconType
+   */
   icon: IconType
 }
 export type ToggleButtonProps = IconButtonProps & {
+  /**
+   * ToggleButton의 색상 타입을 정합니다.
+   * @type 'white' | 'black' | 'gray30' | 'primary' | 'primaryWeak' | 'sub' | 'subWeak' | undefined
+   */
   colorType?: IconButtonColorType
+
+  /**
+   * ToggleButton이 toggle된 경우의 색상 타입을 정합니다.
+   * @type 'white' | 'black' | 'gray30' | 'primary' | 'primaryWeak' | 'sub' | 'subWeak' | undefined
+   */
   toggleColorType?: IconButtonColorType
 } & ToggleButtonType
 

--- a/src/components/ToggleButton/index.tsx
+++ b/src/components/ToggleButton/index.tsx
@@ -13,7 +13,7 @@ type FillIconType = Extract<
 >
 interface FillToggleButton {
   /**
-   * ToggleButton의 스타일 타입을 정합니다.
+   * ToggleButton의 보여질 형태를 정합니다.
    * @type 'fill'
    */
   styleType: 'fill'
@@ -26,13 +26,13 @@ interface FillToggleButton {
 }
 interface StrokeToggleButton {
   /**
-   * ToggleButton으로 아이콘의 타입을 정합니다.
+   * ToggleButton의 보여질 형태를 정합니다.
    * @type 'stroke'
    */
   styleType: 'stroke'
 
   /**
-   * ToggleButton.
+   * ToggleButton의 styleType이 'stoke'인 경우 사용 가능한 아이콘 타입을 정합니다.
    * @type IconType
    */
   icon: IconType

--- a/src/hooks/useClickAway.ts
+++ b/src/hooks/useClickAway.ts
@@ -3,6 +3,11 @@ import type { RefObject } from 'react'
 
 const events = ['mousedown', 'touchstart']
 
+/** ref 외부 클릭 시, 특정 함수를 실행하는 hook입니다.
+ * @param { handler:(e?:Event) => void } ref 외부 클릭시 실행할 handler 함수를 받습니다.
+ * @return { ref: RefObject<T> } 클릭에서 제외할 ref를 반환합니다.
+ */
+
 export const useClickAway = <T extends HTMLElement>(
   handler: (e?: Event) => void
 ): RefObject<T> => {


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #65 

## ⛳ 구현 사항
- 타입을 설명하는 jsdoc을 추가하는 작업
- ToggleButton prop name 변경

## 📚 구현 설명
- Icon, IconButton, ToggleButton, ImageModal, Modal, Text, Button, Input 컴포넌트 prop type을 jsdoc으로 설명 추가
- ToggleButton(type => styleType)

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->