### PR TITLE
refactor: forwardRef 적용 및 HTMLAttribute 타입 리팩터링

### DIFF
--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -38,6 +38,7 @@
     ],
     "react/jsx-pascal-case": ["error"],
     "react/react-in-jsx-scope": "off",
+    "react/prop-types":"off",
     "react/self-closing-comp": [
       "error",
       {

--- a/packages/react/src/components/Avatar/index.tsx
+++ b/packages/react/src/components/Avatar/index.tsx
@@ -1,5 +1,6 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
 import { colors } from '@styles/themes'
+import { forwardRef } from 'react'
 import { Icon } from '@components/Icon'
 import { Image } from '@components/Image'
 import styled from '@emotion/styled'
@@ -36,18 +37,16 @@ const AVATAR_IMAGE_SIZE = {
   xsmall: 16
 } as const
 
-export const Avatar = ({
-  alt,
-  src,
-  size = 'small',
-  ...props
-}: AvatarProps): ReactElement => {
+export const Avatar = forwardRef(function Avatar(
+  { alt, src, size = 'small', ...props }: AvatarProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   const isBlank = src === ''
 
   return (
     <>
       {!isBlank && (
-        <div {...props}>
+        <div ref={ref} {...props}>
           <Image
             alt={alt}
             boxSize={AVATAR_WRAPPER_SIZE[size]}
@@ -57,7 +56,7 @@ export const Avatar = ({
         </div>
       )}
       {isBlank && (
-        <StyledBlankAvatarWrapper size={size} {...props}>
+        <StyledBlankAvatarWrapper ref={ref} size={size} {...props}>
           <Icon
             color={colors.grayScale.gray20}
             size={AVATAR_IMAGE_SIZE[size]}
@@ -67,7 +66,7 @@ export const Avatar = ({
       )}
     </>
   )
-}
+})
 
 const StyledBlankAvatarWrapper = styled.div<StyledBlankAvatarWrapperProps>`
   display: flex;

--- a/packages/react/src/components/Badge/index.tsx
+++ b/packages/react/src/components/Badge/index.tsx
@@ -1,5 +1,6 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
 import type { Colors } from '@themes/colors'
+import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import { Text } from '@components/Text'
 
@@ -19,17 +20,16 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
 type StyledBadgeProps = Pick<BadgeProps, 'colorType'>
 type ApplyColorScheme = (colorType: BadgeColorType, colors: Colors) => string
 
-export const Badge = ({
-  colorType,
-  children,
-  ...props
-}: BadgeProps): ReactElement => {
+export const Badge = forwardRef(function Badge(
+  { colorType, children, ...props }: BadgeProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   return (
-    <StyledBadge colorType={colorType} {...props}>
+    <StyledBadge ref={ref} colorType={colorType} {...props}>
       <Text styleType="caption01M">{children}</Text>
     </StyledBadge>
   )
-}
+})
 
 const applyColorScheme: ApplyColorScheme = (colorScheme, colors) => {
   switch (colorScheme) {

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -1,4 +1,5 @@
-import type { ButtonHTMLAttributes, ReactElement } from 'react'
+import type { ButtonHTMLAttributes, ForwardedRef } from 'react'
+import { forwardRef } from 'react'
 import { Icon } from '@components/Icon'
 import type { IconType } from '@components/Icon'
 import styled from '@emotion/styled'
@@ -55,20 +56,23 @@ const FONT_COLOR = {
   solidSub: 'gray90'
 } as const
 
-export const Button = ({
-  size = 'medium',
-  styleType = 'solidPrimary',
-  icon,
-  children,
-  ...props
-}: ButtonProps): ReactElement => {
+export const Button = forwardRef(function Button(
+  {
+    size = 'medium',
+    styleType = 'solidPrimary',
+    icon,
+    children,
+    ...props
+  }: ButtonProps,
+  ref: ForwardedRef<HTMLButtonElement>
+) {
   return (
-    <StyledButton size={size} styleType={styleType} {...props}>
+    <StyledButton ref={ref} size={size} styleType={styleType} {...props}>
       {icon && <StyledIcon styleType={styleType} type={icon} />}
       {children}
     </StyledButton>
   )
-}
+})
 
 const StyledButton = styled.button<StyledButtonProps>`
   display: flex;

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ButtonHTMLAttributes, ReactElement } from 'react'
 import { Icon } from '@components/Icon'
 import type { IconType } from '@components/Icon'
 import styled from '@emotion/styled'
@@ -7,7 +7,7 @@ import type { Theme } from '@emotion/react'
 
 type ButtonStyleType = typeof BUTTON_STYLE_KEYS[keyof typeof BUTTON_STYLE_KEYS]
 type ButtonSize = 'small' | 'medium' | 'large'
-export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * Button의 보여질 형태를 정합니다.
    * @type "ghost" | "outline" | "outlineDisabled" | "solidDisabled" | "solidPrimary" | "solidSub" | undefined

--- a/packages/react/src/components/Carousel/index.tsx
+++ b/packages/react/src/components/Carousel/index.tsx
@@ -1,10 +1,10 @@
-import type { ReactElement, TouchEventHandler } from 'react'
+import type { HTMLAttributes, ReactElement, TouchEventHandler } from 'react'
 import { useEffect, useState } from 'react'
 import { Icon } from '@components/Icon'
 import styled from '@emotion/styled'
 import { useMediaQuery } from '@hooks'
 
-export interface CarouselProps {
+export interface CarouselProps extends HTMLAttributes<HTMLDivElement> {
   /** Carousel 컴포넌트에 들어갈 이미지들을 정합니다.
    * @type { url: string, id: number } []
    */
@@ -60,7 +60,8 @@ export const Carousel = ({
   images,
   isArrow,
   size = 687,
-  name
+  name,
+  ...props
 }: CarouselProps): ReactElement => {
   const isDesktop = useMediaQuery(`(min-width:1023px)`)
   const carouselWidthSize = isDesktop ? size : FULL_SCREEN_WIDTH
@@ -124,7 +125,7 @@ export const Carousel = ({
   }, [startClientX, endClientX])
 
   return (
-    <StyledCarouselWrapper>
+    <StyledCarouselWrapper {...props}>
       <StyledSlider
         cursorOn={cursorOn}
         size={carouselWidthSize}

--- a/packages/react/src/components/Carousel/index.tsx
+++ b/packages/react/src/components/Carousel/index.tsx
@@ -1,5 +1,5 @@
-import type { HTMLAttributes, ReactElement, TouchEventHandler } from 'react'
-import { useEffect, useState } from 'react'
+import type { ForwardedRef, HTMLAttributes, TouchEventHandler } from 'react'
+import { forwardRef, useEffect, useState } from 'react'
 import { Icon } from '@components/Icon'
 import styled from '@emotion/styled'
 import { useMediaQuery } from '@hooks'
@@ -56,13 +56,10 @@ const NAV_TYPE = {
 const FULL_SCREEN_WIDTH = 100
 const USER_DRAG_LENGTH = 100
 
-export const Carousel = ({
-  images,
-  isArrow,
-  size = 687,
-  name,
-  ...props
-}: CarouselProps): ReactElement => {
+export const Carousel = forwardRef(function Carousel(
+  { images, isArrow, size = 687, name, ...props }: CarouselProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   const isDesktop = useMediaQuery(`(min-width:1023px)`)
   const carouselWidthSize = isDesktop ? size : FULL_SCREEN_WIDTH
   const lastImageValue = carouselWidthSize * (images.length - 1)
@@ -125,7 +122,7 @@ export const Carousel = ({
   }, [startClientX, endClientX])
 
   return (
-    <StyledCarouselWrapper {...props}>
+    <StyledCarouselWrapper ref={ref} {...props}>
       <StyledSlider
         cursorOn={cursorOn}
         size={carouselWidthSize}
@@ -190,7 +187,7 @@ export const Carousel = ({
       </StyledIndicatorBox>
     </StyledCarouselWrapper>
   )
-}
+})
 
 const StyledCarouselWrapper = styled.div`
   touch-action: none;

--- a/packages/react/src/components/ChattingBubble/index.tsx
+++ b/packages/react/src/components/ChattingBubble/index.tsx
@@ -1,4 +1,5 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
+import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import { Text } from '@components/Text'
 import { useMediaQuery } from '@hooks'
@@ -18,11 +19,10 @@ interface StyledBubbleProps {
   isSend: boolean
 }
 
-export const ChattingBubble = ({
-  messageType,
-  children,
-  ...props
-}: ChattingBubbleProps): ReactElement => {
+export const ChattingBubble = forwardRef(function ChattingBubble(
+  { messageType, children, ...props }: ChattingBubbleProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   const newLineRegex = /\s/gi
   const blankChatLength = children.length
   const noBlankChatLength = children.replace(newLineRegex, '').length
@@ -34,7 +34,7 @@ export const ChattingBubble = ({
   const mobileTextStyleType = isSend ? 'body02M' : 'body02R'
 
   return (
-    <StyledBubble {...props} isSend={isSend}>
+    <StyledBubble ref={ref} {...props} isSend={isSend}>
       <StyledChattingMessage
         isSend={isSend}
         styleType={isDesktop ? desktopTextStyleType : mobileTextStyleType}>
@@ -47,7 +47,7 @@ export const ChattingBubble = ({
       </StyledChattingMessage>
     </StyledBubble>
   )
-}
+})
 
 const StyledBubble = styled.p<StyledBubbleProps>`
   display: inline-block;

--- a/packages/react/src/components/Divider/index.tsx
+++ b/packages/react/src/components/Divider/index.tsx
@@ -1,4 +1,5 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
+import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 
 export interface DividerProps extends HTMLAttributes<HTMLDivElement> {
@@ -13,17 +14,16 @@ export interface DividerProps extends HTMLAttributes<HTMLDivElement> {
 }
 type StyledDividerProps = Pick<DividerProps, 'direction'>
 
-export const Divider = ({
-  direction = 'horizontal',
-  size = 'regular',
-  ...props
-}: DividerProps): ReactElement => {
+export const Divider = forwardRef(function Divider(
+  { direction = 'horizontal', size = 'regular', ...props }: DividerProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   return (
-    <StyledDividerWrapper direction={direction} {...props}>
+    <StyledDividerWrapper ref={ref} direction={direction} {...props}>
       <StyledDivider direction={direction} size={size} />
     </StyledDividerWrapper>
   )
-}
+})
 
 const StyledDividerWrapper = styled.div<StyledDividerProps>`
   display: ${({ direction }): string =>

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -33,12 +33,12 @@ import {
   Store,
   TriangleDown
 } from '@constants/icons'
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ReactElement, SVGAttributes } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 
 export type IconType = keyof typeof ICON_TYPES
-export interface IconProps extends HTMLAttributes<HTMLOrSVGElement> {
+export interface IconProps extends SVGAttributes<HTMLOrSVGElement> {
   /**
    * Icon의 크기를 정합니다.
    * @type number | undefined

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -33,7 +33,8 @@ import {
   Store,
   TriangleDown
 } from '@constants/icons'
-import type { ReactElement, SVGAttributes } from 'react'
+import type { ForwardedRef, SVGAttributes } from 'react'
+import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 
@@ -93,20 +94,18 @@ export const ICON_TYPES = {
   triangleDown: TriangleDown
 } as const
 
-export const Icon = ({
-  type,
-  size = 24,
-  color = 'black',
-  ...props
-}: IconProps): ReactElement => {
+export const Icon = forwardRef(function Icon(
+  { type, size = 24, color = 'black', ...props }: IconProps,
+  ref: ForwardedRef<SVGSVGElement>
+) {
   const IconSvg = ICON_TYPES[type]
 
   return (
     <StyledIconWrapper color={color}>
-      <IconSvg height={size} width={size} {...props} />
+      <IconSvg ref={ref} height={size} width={size} {...props} />
     </StyledIconWrapper>
   )
-}
+})
 
 const StyledIconWrapper = styled.i<StyledIconWrapperProps>`
   display: flex;

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -1,4 +1,5 @@
-import type { ButtonHTMLAttributes, ReactElement } from 'react'
+import type { ButtonHTMLAttributes, ForwardedRef } from 'react'
+import { forwardRef } from 'react'
 import { Icon } from '@components/Icon'
 import type { IconType } from '@components/Icon'
 import styled from '@emotion/styled'
@@ -68,17 +69,21 @@ const ICON_BUTTON_SIZE = {
   }
 }
 
-export const IconButton = ({
-  colorType = 'black',
-  size = 'small',
-  shape = 'ghost',
-  hasShadow = false,
-  icon,
-  ...props
-}: IconButtonProps): ReactElement => {
+export const IconButton = forwardRef(function IconButton(
+  {
+    colorType = 'black',
+    size = 'small',
+    shape = 'ghost',
+    hasShadow = false,
+    icon,
+    ...props
+  }: IconButtonProps,
+  ref: ForwardedRef<HTMLButtonElement>
+) {
   return (
     <StyledIconButton
       {...props}
+      ref={ref}
       colorType={colorType}
       hasShadow={hasShadow}
       shape={shape}
@@ -91,7 +96,7 @@ export const IconButton = ({
       />
     </StyledIconButton>
   )
-}
+})
 
 const StyledIconButton = styled.button<StyledIconButtonProps>`
   display: flex;

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ButtonHTMLAttributes, ReactElement } from 'react'
 import { Icon } from '@components/Icon'
 import type { IconType } from '@components/Icon'
 import styled from '@emotion/styled'
@@ -16,7 +16,8 @@ export type IconButtonColorType =
 type IconButtonSize = 'small' | 'medium' | 'large'
 type IconButtonShape = 'rounded' | 'square' | 'ghost'
 
-export interface IconButtonProps extends HTMLAttributes<HTMLButtonElement> {
+export interface IconButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * IconButton으로 사용될 아이콘의 타입을 정합니다.
    * @type IconType

--- a/packages/react/src/components/Image/index.tsx
+++ b/packages/react/src/components/Image/index.tsx
@@ -1,11 +1,11 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ImgHTMLAttributes, ReactElement } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 import { useImage } from '@hooks'
 
 type ObjectFit = 'fill' | 'contain' | 'cover' | 'none'
 
-export interface ImageProps extends HTMLAttributes<HTMLImageElement> {
+export interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   /** image의 alt 속성을 정합니다.
    * @type string
    */

--- a/packages/react/src/components/Image/index.tsx
+++ b/packages/react/src/components/Image/index.tsx
@@ -1,4 +1,5 @@
-import type { ImgHTMLAttributes, ReactElement } from 'react'
+import type { ForwardedRef, ImgHTMLAttributes } from 'react'
+import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 import { useImage } from '@hooks'
@@ -52,17 +53,20 @@ interface ApplyShapeParams {
 }
 type ApplyShape = (params: ApplyShapeParams) => string
 
-export const Image = ({
-  alt,
-  src,
-  fallbackSrc,
-  objectFit = 'cover',
-  width = '',
-  height = '',
-  boxSize = '276px',
-  radius = '0px',
-  ...props
-}: ImageProps): ReactElement => {
+export const Image = forwardRef(function Image(
+  {
+    alt,
+    src,
+    fallbackSrc,
+    objectFit = 'cover',
+    width = '',
+    height = '',
+    boxSize = '276px',
+    radius = '0px',
+    ...props
+  }: ImageProps,
+  ref: ForwardedRef<HTMLImageElement>
+) {
   const { onFallbackError, onLoadImage, status } = useImage({
     fallbackSrc,
     src
@@ -73,6 +77,7 @@ export const Image = ({
   if (isShowFallback) {
     return (
       <StyledImage
+        ref={ref}
         alt={alt}
         boxSize={boxSize}
         height={height}
@@ -90,6 +95,7 @@ export const Image = ({
     <>
       {!isLoaded && (
         <StyledPlaceholder
+          ref={ref as ForwardedRef<HTMLDivElement>}
           boxSize={boxSize}
           height={height}
           radius={radius}
@@ -99,6 +105,7 @@ export const Image = ({
       )}
       {isLoaded && (
         <StyledImage
+          ref={ref}
           alt={alt}
           boxSize={boxSize}
           height={height}
@@ -112,7 +119,7 @@ export const Image = ({
       )}
     </>
   )
-}
+})
 
 const StyledPlaceholder = styled.div<Omit<StyledImgProps, 'objectFit'>>`
   ${({ boxSize, radius, theme, width, height }): string => `

--- a/packages/react/src/components/ImageModal/index.tsx
+++ b/packages/react/src/components/ImageModal/index.tsx
@@ -1,5 +1,5 @@
-import type { HTMLAttributes, ReactElement, TouchEventHandler } from 'react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import type { ForwardedRef, HTMLAttributes, TouchEventHandler } from 'react'
+import { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
 import { IconButton } from '@components/IconButton'
 import { Image as ImageComponent } from '@components/Image'
 import ReactDOM from 'react-dom'
@@ -61,13 +61,10 @@ const VALUE_OF_TOUCH_NAV_TYPE = {
   right: 1
 } as const
 
-export const ImageModal = ({
-  onClose,
-  images,
-  isOpen = false,
-  name,
-  ...props
-}: ImageModalProps): ReactElement => {
+export const ImageModal = forwardRef(function ImageModal(
+  { onClose, images, isOpen = false, name, ...props }: ImageModalProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   const imagesInfo = useRef<ResizeImageInfo[]>([])
   const initImageId = images[0].id
   const [currentImageId, setCurrentImageId] = useState<string>(initImageId)
@@ -77,7 +74,7 @@ export const ImageModal = ({
   useEffect(() => {
     document.body.append(topElement)
 
-    return () => {
+    return (): void => {
       document.body.removeChild(topElement)
     }
   }, [])
@@ -189,6 +186,7 @@ export const ImageModal = ({
       />
       <StyledImageContainer
         {...props}
+        ref={ref}
         currentImageIndex={getCurrentImageIndex()}
         sumOfHandoverImageWidth={getSumOfHandoverImageWidth()}>
         {imagesInfo.current.map(({ src, id, width, height }) => (
@@ -218,7 +216,7 @@ export const ImageModal = ({
     </StyledDIM>,
     topElement
   )
-}
+})
 
 const StyledDIM = styled.div<StyledDIMProps>`
   position: absolute;

--- a/packages/react/src/components/ImageUploader/index.tsx
+++ b/packages/react/src/components/ImageUploader/index.tsx
@@ -1,11 +1,12 @@
 import type {
   ChangeEventHandler,
+  ForwardedRef,
   HTMLAttributes,
-  MutableRefObject,
-  ReactElement
+  MutableRefObject
 } from 'react'
 import { DesktopUploader, MobileUploader } from './uploader'
 import type { ImageInfo, UploaderOnChangeHandler } from '@types'
+import { forwardRef } from 'react'
 import { useImageUploader } from './useImageUploader'
 import { useMediaQuery } from '@hooks'
 
@@ -32,11 +33,10 @@ export type ImageUploaderProps = {
 
 const MAX_LIST_LENGTH = 10
 
-export const ImageUploader = ({
-  images: defaultImages,
-  onChange,
-  ...props
-}: ImageUploaderProps): ReactElement => {
+export const ImageUploader = forwardRef(function ImageUploader(
+  { images: defaultImages, onChange, ...props }: ImageUploaderProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   const {
     imageListRef,
     uploaderRef,
@@ -56,6 +56,7 @@ export const ImageUploader = ({
 
   return (
     <Uploader
+      ref={ref}
       addImage={addImage}
       imageListRef={imageListRef}
       images={images}
@@ -68,4 +69,4 @@ export const ImageUploader = ({
       {...props}
     />
   )
-}
+})

--- a/packages/react/src/components/ImageUploader/uploader/DesktopUploader.tsx
+++ b/packages/react/src/components/ImageUploader/uploader/DesktopUploader.tsx
@@ -1,7 +1,8 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Badge } from '@components/Badge'
 import { Button } from '@components/Button'
 import { colors } from '@themes'
+import { forwardRef } from 'react'
 import { Icon } from '@components/Icon'
 import { Image } from '@components/Image'
 import styled from '@emotion/styled'
@@ -20,20 +21,23 @@ type DesktopUploaderProps = {
 } & UploaderProps &
   HTMLAttributes<HTMLDivElement>
 
-export const DesktopUploader = ({
-  imageListRef,
-  uploaderRef,
-  images,
-  openUploader,
-  addImage,
-  removeImage,
-  isShowListType,
-  isMaximum,
-  imgTotal,
-  ...props
-}: DesktopUploaderProps): ReactElement => {
+export const DesktopUploader = forwardRef(function DesktopUploader(
+  {
+    imageListRef,
+    uploaderRef,
+    images,
+    openUploader,
+    addImage,
+    removeImage,
+    isShowListType,
+    isMaximum,
+    imgTotal,
+    ...props
+  }: DesktopUploaderProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   return (
-    <StyledUploaderWrapper isShowListType={isShowListType} {...props}>
+    <StyledUploaderWrapper ref={ref} isShowListType={isShowListType} {...props}>
       <StyledTriggerWrapper onClick={openUploader}>
         <StyledTrigger isShowListType={isShowListType}>
           <Icon color={colors.grayScale.gray30} size={40} type="picture" />
@@ -73,7 +77,7 @@ export const DesktopUploader = ({
       </StyledImageList>
     </StyledUploaderWrapper>
   )
-}
+})
 
 const StyledUploaderWrapper = styled.div<Pick<StyledProps, 'isShowListType'>>`
   ${({ theme, isShowListType }): string => `

--- a/packages/react/src/components/ImageUploader/uploader/MobileUploader.tsx
+++ b/packages/react/src/components/ImageUploader/uploader/MobileUploader.tsx
@@ -1,6 +1,7 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Badge } from '@components/Badge'
 import { colors } from '@themes'
+import { forwardRef } from 'react'
 import { Icon } from '@components/Icon'
 import { Image } from '@components/Image'
 import styled from '@emotion/styled'
@@ -19,20 +20,23 @@ type MobileUploaderProps = {
 } & UploaderProps &
   HTMLAttributes<HTMLDivElement>
 
-export const MobileUploader = ({
-  imageListRef,
-  uploaderRef,
-  images,
-  openUploader,
-  addImage,
-  removeImage,
-  isShowListType,
-  isMaximum,
-  imgTotal,
-  ...props
-}: MobileUploaderProps): ReactElement => {
+export const MobileUploader = forwardRef(function MobileUploader(
+  {
+    imageListRef,
+    uploaderRef,
+    images,
+    openUploader,
+    addImage,
+    removeImage,
+    isShowListType,
+    isMaximum,
+    imgTotal,
+    ...props
+  }: MobileUploaderProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   return (
-    <StyledUploaderWrapper isShowListType={isShowListType} {...props}>
+    <StyledUploaderWrapper ref={ref} isShowListType={isShowListType} {...props}>
       <StyledTrigger onClick={openUploader}>
         <Icon color={colors.grayScale.gray30} size={40} type="picture" />
         <StyledImageTotal isMaximum={isMaximum} styleType="caption01M">
@@ -64,7 +68,7 @@ export const MobileUploader = ({
       </StyledImageList>
     </StyledUploaderWrapper>
   )
-}
+})
 
 const StyledUploaderWrapper = styled.div<Pick<StyledProps, 'isShowListType'>>`
   ${({ theme, isShowListType }): string => `

--- a/packages/react/src/components/Input/ChattingInput.tsx
+++ b/packages/react/src/components/Input/ChattingInput.tsx
@@ -1,9 +1,9 @@
-import type { ChangeEventHandler, ReactElement } from 'react'
+import type { ChangeEventHandler, ForwardedRef } from 'react'
+import { forwardRef, useState } from 'react'
 import { IconButton } from '@components/IconButton'
 import type { MainInputProps } from './index'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
-import { useState } from 'react'
 
 type ChattingInputProps = Omit<
   MainInputProps,
@@ -15,11 +15,10 @@ type StyledIconButtonProps = StyledInputProps & {
   disabled: boolean
 }
 
-export const ChattingInput = ({
-  isSmall,
-  onChange,
-  ...props
-}: ChattingInputProps): ReactElement => {
+export const ChattingInput = forwardRef(function ChattingInput(
+  { isSmall, onChange, ...props }: ChattingInputProps,
+  ref: ForwardedRef<HTMLInputElement>
+) {
   const [inputValue, setInputValue] = useState<string>('')
   const isDisabled = !inputValue
 
@@ -30,7 +29,12 @@ export const ChattingInput = ({
 
   return (
     <StyledInputForm>
-      <StyledInput isSmall={isSmall} onChange={handleChange} {...props} />
+      <StyledInput
+        ref={ref}
+        isSmall={isSmall}
+        onChange={handleChange}
+        {...props}
+      />
       <StyledIconButton
         colorType={isDisabled ? 'primaryWeak' : 'primary'}
         disabled={isDisabled}
@@ -41,7 +45,7 @@ export const ChattingInput = ({
       />
     </StyledInputForm>
   )
-}
+})
 
 const StyledInputForm = styled.form`
   display: inline-flex;

--- a/packages/react/src/components/Input/DefaultInput.tsx
+++ b/packages/react/src/components/Input/DefaultInput.tsx
@@ -1,6 +1,7 @@
-import type { ChangeEventHandler, ReactElement } from 'react'
+import type { ChangeEventHandler, ForwardedRef } from 'react'
 import { convertToNumber, toLocaleCurrency } from '@utils/format'
 import type { MainInputProps as DefaultInputProps } from './index'
+import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 import { Text } from '@components/Text'
@@ -11,15 +12,18 @@ type StyledInputProps = StyledProps<DefaultInputProps, 'isPrice'> &
   StyledPriceUnitProps
 type StyledStatusProps = StyledProps<DefaultInputProps, 'status'>
 
-export const DefaultInput = ({
-  label,
-  status = 'default',
-  guideMessage = '',
-  isPrice = false,
-  isSmall,
-  onChange,
-  ...args
-}: DefaultInputProps): ReactElement => {
+export const DefaultInput = forwardRef(function DefaultInput(
+  {
+    label,
+    status = 'default',
+    guideMessage = '',
+    isPrice = false,
+    isSmall,
+    onChange,
+    ...args
+  }: DefaultInputProps,
+  ref: ForwardedRef<HTMLInputElement>
+) {
   const hasGuideMessage = status !== 'none'
   const handleInputChange: ChangeEventHandler<HTMLInputElement> = e => {
     if (isPrice) {
@@ -36,6 +40,7 @@ export const DefaultInput = ({
       <StyledLabel>
         {label && <Text styleType="body01M">{label}</Text>}
         <StyledInput
+          ref={ref}
           isPrice={isPrice}
           isSmall={isSmall}
           onChange={handleInputChange}
@@ -56,7 +61,7 @@ export const DefaultInput = ({
       )}
     </StyledWrapper>
   )
-}
+})
 
 const StyledWrapper = styled.div`
   display: inline-flex;

--- a/packages/react/src/components/Input/EditInput.tsx
+++ b/packages/react/src/components/Input/EditInput.tsx
@@ -1,5 +1,6 @@
-import type { ChangeEventHandler, ReactElement } from 'react'
+import type { ChangeEventHandler, ForwardedRef } from 'react'
 import { convertToNumber, toLocaleCurrency } from '@utils/format'
+import { forwardRef } from 'react'
 import type { MainInputProps } from './index'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
@@ -13,14 +14,17 @@ interface StyledInputProps {
 }
 type StyledGuideMessageProps = StyledProps<EditInputProps, 'status'>
 
-export const EditInput = ({
-  label = '',
-  guideMessage = '',
-  status = 'default',
-  isSmall,
-  onChange,
-  ...props
-}: EditInputProps): ReactElement => {
+export const EditInput = forwardRef(function EditInput(
+  {
+    label = '',
+    guideMessage = '',
+    status = 'default',
+    isSmall,
+    onChange,
+    ...props
+  }: EditInputProps,
+  ref: ForwardedRef<HTMLInputElement>
+) {
   const hasGuideMessage = status !== 'none'
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = e => {
@@ -34,7 +38,12 @@ export const EditInput = ({
     <StyledInputForm>
       <StyledInputLabel>
         {label && <Text styleType="body01M">{label}</Text>}
-        <StyledInput isSmall={isSmall} onChange={handleChange} {...props} />
+        <StyledInput
+          ref={ref}
+          isSmall={isSmall}
+          onChange={handleChange}
+          {...props}
+        />
         <StyledPriceUnit isSmall={isSmall} styleType="subtitle01M">
           {VALIDATE_MESSAGE.PRICE_UNIT}
         </StyledPriceUnit>
@@ -46,7 +55,7 @@ export const EditInput = ({
       )}
     </StyledInputForm>
   )
-}
+})
 
 const StyledInputForm = styled.form`
   display: inline-flex;

--- a/packages/react/src/components/Input/SearchInput.tsx
+++ b/packages/react/src/components/Input/SearchInput.tsx
@@ -1,7 +1,8 @@
 import { colors } from '@themes'
+import type { ForwardedRef } from 'react'
+import { forwardRef } from 'react'
 import { Icon } from '@components/Icon'
 import type { MainInputProps } from './index'
-import type { ReactElement } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 
@@ -11,10 +12,10 @@ type SearchInputProps = Omit<
 >
 type StyledInputProps = StyledProps<SearchInputProps, 'isSmall'>
 
-export const SearchInput = ({
-  isSmall,
-  ...props
-}: SearchInputProps): ReactElement => {
+export const SearchInput = forwardRef(function SearchInput(
+  { isSmall, ...props }: SearchInputProps,
+  ref: ForwardedRef<HTMLInputElement>
+) {
   return (
     <StyledInputForm>
       <StyledIcon
@@ -22,10 +23,10 @@ export const SearchInput = ({
         isSmall={isSmall}
         type="search"
       />
-      <StyledInput isSmall={isSmall} {...props} />
+      <StyledInput ref={ref} isSmall={isSmall} {...props} />
     </StyledInputForm>
   )
-}
+})
 
 const StyledInputForm = styled.form`
   display: inline-flex;

--- a/packages/react/src/components/Input/index.tsx
+++ b/packages/react/src/components/Input/index.tsx
@@ -1,7 +1,8 @@
-import type { InputHTMLAttributes, ReactElement } from 'react'
+import type { ForwardedRef, InputHTMLAttributes, ReactElement } from 'react'
 import { ChattingInput } from './ChattingInput'
 import { DefaultInput } from './DefaultInput'
 import { EditInput } from './EditInput'
+import { forwardRef } from 'react'
 import { SearchInput } from './SearchInput'
 
 type InputStyleType = typeof INPUT_STYLE_KEYS[keyof typeof INPUT_STYLE_KEYS]
@@ -49,11 +50,10 @@ export const INPUT_STYLE_KEYS = {
   SEARCH: 'search'
 } as const
 
-export const Input = ({
-  styleType = 'default',
-  inputSize = 'small',
-  ...props
-}: InputProps): ReactElement => {
+export const Input = forwardRef(function Input(
+  { styleType = 'default', inputSize = 'small', ...props }: InputProps,
+  ref: ForwardedRef<HTMLInputElement>
+) {
   const renderInput = (styleType: InputStyleType): ReactElement => {
     const { EDIT, DEFAULT, CHATTING, SEARCH } = INPUT_STYLE_KEYS
     const isSmall = inputSize === 'small'
@@ -61,17 +61,17 @@ export const Input = ({
 
     switch (styleType) {
       case DEFAULT:
-        return <DefaultInput {...inputTypeProps} />
+        return <DefaultInput ref={ref} {...inputTypeProps} />
       case CHATTING:
-        return <ChattingInput {...inputTypeProps} />
+        return <ChattingInput ref={ref} {...inputTypeProps} />
       case SEARCH:
-        return <SearchInput {...inputTypeProps} />
+        return <SearchInput ref={ref} {...inputTypeProps} />
       case EDIT:
-        return <EditInput {...inputTypeProps} />
+        return <EditInput ref={ref} {...inputTypeProps} />
       default:
-        return <DefaultInput {...inputTypeProps} />
+        return <DefaultInput ref={ref} {...inputTypeProps} />
     }
   }
 
   return renderInput(styleType)
-}
+})

--- a/packages/react/src/components/Input/index.tsx
+++ b/packages/react/src/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { InputHTMLAttributes, ReactElement } from 'react'
 import { ChattingInput } from './ChattingInput'
 import { DefaultInput } from './DefaultInput'
 import { EditInput } from './EditInput'
@@ -6,7 +6,7 @@ import { SearchInput } from './SearchInput'
 
 type InputStyleType = typeof INPUT_STYLE_KEYS[keyof typeof INPUT_STYLE_KEYS]
 export type InputSize = 'large' | 'small'
-export interface InputProps extends HTMLAttributes<HTMLInputElement> {
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   /**
    * Input의 스타일 타입을 정합니다.
    * @type "chatting" | "default" | "edit" | "search" | undefined

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -1,6 +1,7 @@
-import type { HTMLAttributes, ReactElement } from 'react'
-import { useEffect, useMemo } from 'react'
+import type { ForwardedRef, HTMLAttributes, ReactElement } from 'react'
+import { forwardRef, useEffect, useMemo } from 'react'
 import { IconButton } from '@components/IconButton'
+import { mergeRefs } from '@utils/mergeRefs'
 import ReactDOM from 'react-dom'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
@@ -37,14 +38,17 @@ export interface ModalProps extends HTMLAttributes<HTMLDivElement> {
 type StyledModalProps = StyledProps<ModalProps, 'width' | 'height'>
 type StyledDIMProps = StyledProps<ModalProps, 'isOpen'>
 
-export const Modal = ({
-  children,
-  width = 400,
-  height = 0,
-  onClose,
-  isOpen = false,
-  ...props
-}: ModalProps): ReactElement => {
+export const Modal = forwardRef(function Modal(
+  {
+    children,
+    width = 400,
+    height = 0,
+    onClose,
+    isOpen = false,
+    ...props
+  }: ModalProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   const modalRef = useClickAway<HTMLDivElement>(() => {
     onClose?.()
   })
@@ -53,14 +57,18 @@ export const Modal = ({
   useEffect(() => {
     document.body.append(topElement)
 
-    return () => {
+    return (): void => {
       document.body.removeChild(topElement)
     }
   }, [])
 
   return ReactDOM.createPortal(
     <StyledDIM isOpen={isOpen}>
-      <StyledModal {...props} ref={modalRef} height={height} width={width}>
+      <StyledModal
+        {...props}
+        ref={mergeRefs([modalRef, ref])}
+        height={height}
+        width={width}>
         <StyledCloseIcon
           colorType="gray30"
           icon="close"
@@ -72,7 +80,7 @@ export const Modal = ({
     </StyledDIM>,
     topElement
   )
-}
+})
 
 const StyledDIM = styled.div<StyledDIMProps>`
   position: absolute;

--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -1,9 +1,9 @@
-import type { ChangeEvent, HTMLAttributes, ReactElement } from 'react'
+import type { ChangeEvent, FormHTMLAttributes, ReactElement } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 import { Text } from '@components/Text'
 
-export interface RadioProps extends HTMLAttributes<HTMLFormElement> {
+export interface RadioProps extends FormHTMLAttributes<HTMLFormElement> {
   /** Radio 컴포넌트의 이름을 정합니다.(input name에 사용)
    * @type string
    */

--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -1,4 +1,5 @@
-import type { ChangeEvent, FormHTMLAttributes, ReactElement } from 'react'
+import type { ChangeEvent, FormHTMLAttributes, ForwardedRef } from 'react'
+import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 import { Text } from '@components/Text'
@@ -24,13 +25,10 @@ export interface RadioProps extends FormHTMLAttributes<HTMLFormElement> {
 
 type StyledFormProps = StyledProps<RadioProps, 'direction'>
 
-export const Radio = ({
-  formName,
-  onChange,
-  items,
-  direction = 'horizontal',
-  ...props
-}: RadioProps): ReactElement => {
+export const Radio = forwardRef(function Radio(
+  { formName, onChange, items, direction = 'horizontal', ...props }: RadioProps,
+  ref: ForwardedRef<HTMLFormElement>
+) {
   const handleRadiobutton = (
     e: ChangeEvent<HTMLInputElement> & ChangeEvent<HTMLFormElement>
   ): void => {
@@ -52,11 +50,11 @@ export const Radio = ({
   ))
 
   return (
-    <StyledForm {...props} direction={direction}>
+    <StyledForm ref={ref} {...props} direction={direction}>
       {radioList}
     </StyledForm>
   )
-}
+})
 
 const StyledForm = styled.form<StyledFormProps>`
   display: ${({ direction }): string =>

--- a/packages/react/src/components/Text/index.tsx
+++ b/packages/react/src/components/Text/index.tsx
@@ -1,5 +1,6 @@
-import type { HTMLAttributes, ReactElement } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
 import type { FontStyleKeys } from '@themes'
+import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@types'
 
@@ -28,19 +29,27 @@ export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
 
 type StyledTextProps = StyledProps<TextProps, 'styleType' | 'color'>
 
-export const Text = ({
-  tag = 'span',
-  children,
-  styleType: textStyle = 'body01M',
-  color = '',
-  ...props
-}: TextProps): ReactElement => {
+export const Text = forwardRef(function Text(
+  {
+    tag = 'span',
+    children,
+    styleType: textStyle = 'body01M',
+    color = '',
+    ...props
+  }: TextProps,
+  ref: ForwardedRef<HTMLSpanElement>
+) {
   return (
-    <StyledText as={tag} color={color} styleType={textStyle} {...props}>
+    <StyledText
+      ref={ref}
+      as={tag}
+      color={color}
+      styleType={textStyle}
+      {...props}>
       {children}
     </StyledText>
   )
-}
+})
 
 const StyledText = styled.span<StyledTextProps>`
   ${({ color }): string => (color ? `color: ${color}` : '')};

--- a/packages/react/src/components/Textarea/index.tsx
+++ b/packages/react/src/components/Textarea/index.tsx
@@ -1,9 +1,10 @@
-import type { ChangeEvent, HTMLAttributes, ReactElement } from 'react'
+import type { ChangeEvent, ReactElement, TextareaHTMLAttributes } from 'react'
 import styled from '@emotion/styled'
 import { Text } from '@components/Text'
 import { useRef } from 'react'
 
-export interface TextAreaProps extends HTMLAttributes<HTMLTextAreaElement> {
+export interface TextAreaProps
+  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   /** TextArea 컴포넌트 상단의 label 정합니다.
    * @type string | undefined
    */

--- a/packages/react/src/components/Textarea/index.tsx
+++ b/packages/react/src/components/Textarea/index.tsx
@@ -1,5 +1,6 @@
 import type { ChangeEvent, ForwardedRef, TextareaHTMLAttributes } from 'react'
 import { forwardRef, useRef } from 'react'
+import { mergeRefs } from '@utils/mergeRefs'
 import styled from '@emotion/styled'
 import { Text } from '@components/Text'
 
@@ -58,15 +59,7 @@ export const TextArea = forwardRef(function TextArea(
       </StyledLabel>
       <StyledTextArea
         {...props}
-        ref={(elem): void => {
-          if (typeof ref === 'function') {
-            ref(elem)
-          } else if (ref != null) {
-            ref.current = elem
-          }
-
-          textAreaRef.current = elem
-        }}
+        ref={mergeRefs<HTMLTextAreaElement>([textAreaRef, ref])}
         isFilled={isFilled}
         placeholder={placeholder}
         rows={1}

--- a/packages/react/src/components/Textarea/index.tsx
+++ b/packages/react/src/components/Textarea/index.tsx
@@ -1,7 +1,7 @@
-import type { ChangeEvent, ReactElement, TextareaHTMLAttributes } from 'react'
+import type { ChangeEvent, ForwardedRef, TextareaHTMLAttributes } from 'react'
+import { forwardRef, useRef } from 'react'
 import styled from '@emotion/styled'
 import { Text } from '@components/Text'
-import { useRef } from 'react'
 
 export interface TextAreaProps
   extends TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -26,14 +26,18 @@ export interface TextAreaProps
 interface StyledTextAreaProps {
   isFilled: boolean
 }
-export const TextArea = ({
-  label = '',
-  placeholder = '내용을 입력하세요.',
-  guideMessage = '',
-  bgType = 'filled',
-  onInput,
-  ...props
-}: TextAreaProps): ReactElement => {
+
+export const TextArea = forwardRef(function TextArea(
+  {
+    label = '',
+    placeholder = '내용을 입력하세요.',
+    guideMessage = '',
+    bgType = 'filled',
+    onInput,
+    ...props
+  }: TextAreaProps,
+  ref: ForwardedRef<HTMLTextAreaElement>
+) {
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
   const TEXT_AREA_DEFAULT_HEIGHT = '120px'
   const isFilled = bgType === 'filled'
@@ -54,7 +58,15 @@ export const TextArea = ({
       </StyledLabel>
       <StyledTextArea
         {...props}
-        ref={textAreaRef}
+        ref={(elem): void => {
+          if (typeof ref === 'function') {
+            ref(elem)
+          } else if (ref != null) {
+            ref.current = elem
+          }
+
+          textAreaRef.current = elem
+        }}
         isFilled={isFilled}
         placeholder={placeholder}
         rows={1}
@@ -65,7 +77,7 @@ export const TextArea = ({
       </StyledGuideMessage>
     </>
   )
-}
+})
 
 const StyledLabel = styled.label`
   display: block;

--- a/packages/react/src/components/ToggleButton/index.tsx
+++ b/packages/react/src/components/ToggleButton/index.tsx
@@ -1,11 +1,11 @@
+import type { ForwardedRef, MouseEventHandler } from 'react'
+import { forwardRef, useState } from 'react'
 import type {
   IconButtonColorType,
   IconButtonProps
 } from '@components/IconButton'
-import type { MouseEventHandler, ReactElement } from 'react'
 import { IconButton } from '@components/IconButton'
 import type { IconType } from '@components/Icon'
-import { useState } from 'react'
 
 type FillIconType = Extract<
   IconType,
@@ -50,14 +50,17 @@ export type ToggleButtonProps = IconButtonProps & {
 
 type ToggleButtonType = FillToggleButton | StrokeToggleButton
 
-export const ToggleButton = ({
-  onClick,
-  styleType = 'stroke',
-  colorType = 'black',
-  toggleColorType = colorType,
-  icon,
-  ...props
-}: ToggleButtonProps): ReactElement => {
+export const ToggleButton = forwardRef(function ToggleButton(
+  {
+    onClick,
+    styleType = 'stroke',
+    colorType = 'black',
+    toggleColorType = colorType,
+    icon,
+    ...props
+  }: ToggleButtonProps,
+  ref: ForwardedRef<HTMLButtonElement>
+) {
   const [isToggle, setIsToggle] = useState<boolean>(false)
   const isFillType = styleType === 'fill'
   const toggleIcon = isFillType ? `${icon}Fill` : icon
@@ -74,10 +77,11 @@ export const ToggleButton = ({
 
   return (
     <IconButton
+      ref={ref}
       colorType={renderIcon.color}
       icon={renderIcon.icon as IconType}
       onClick={handleClick}
       {...props}
     />
   )
-}
+})

--- a/packages/react/src/hooks/useClickAway.ts
+++ b/packages/react/src/hooks/useClickAway.ts
@@ -1,16 +1,16 @@
 import { useEffect, useRef } from 'react'
-import type { RefObject } from 'react'
+import type { MutableRefObject } from 'react'
 
 const events = ['mousedown', 'touchstart']
 
 /** ref 외부 클릭 시, 특정 함수를 실행하는 hook입니다.
  * @param { handler:(e?:Event) => void } ref 외부 클릭시 실행할 handler 함수를 받습니다.
- * @return { ref: RefObject<T> } 클릭에서 제외할 ref를 반환합니다.
+ * @return { ref: <T> } 클릭에서 제외할 ref를 반환합니다.
  */
 export const useClickAway = <T extends HTMLElement>(
   handler: (e?: Event) => void
-): RefObject<T> => {
-  const ref = useRef<T>(null)
+): MutableRefObject<T | null> => {
+  const ref = useRef<T | null>(null)
   const savedHandler = useRef(handler)
 
   useEffect(() => {

--- a/packages/react/src/utils/mergeRefs.ts
+++ b/packages/react/src/utils/mergeRefs.ts
@@ -1,0 +1,19 @@
+import type { ForwardedRef, LegacyRef, MutableRefObject } from 'react'
+
+type MergeRefParams<T extends HTMLDivElement> =
+  | MutableRefObject<T | null>[]
+  | ForwardedRef<T>[]
+
+export const mergeRefs = <T extends HTMLDivElement>(
+  refs: MergeRefParams<T>
+): LegacyRef<T> | undefined => {
+  return elem => {
+    refs.forEach(ref => {
+      if (typeof ref === 'function') {
+        ref(elem)
+      } else if (ref !== null) {
+        ref.current = elem
+      }
+    })
+  }
+}

--- a/packages/react/src/utils/mergeRefs.ts
+++ b/packages/react/src/utils/mergeRefs.ts
@@ -1,10 +1,10 @@
 import type { ForwardedRef, LegacyRef, MutableRefObject } from 'react'
 
-type MergeRefParams<T extends HTMLDivElement> =
+type MergeRefParams<T = HTMLDivElement> =
   | MutableRefObject<T | null>[]
   | ForwardedRef<T>[]
 
-export const mergeRefs = <T extends HTMLDivElement>(
+export const mergeRefs = <T = HTMLDivElement>(
   refs: MergeRefParams<T>
 ): LegacyRef<T> | undefined => {
   return elem => {


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #101 

## ⛳ 구현 사항
- 컴포넌트에 forwardRef를 적용하였습니다.
- HTMLAttribute<T> 타입 선언 시, 특정 엘리먼트의 속성을 불러오지 못하는 이슈가 있어 타입을 수정하였습니다.
- 기존의 ref가 적용되어 있는 경우, 추가 ref를 등록하기 위해 mergeRefs 유틸 함수를 구현 하였습니다.

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

## 🔥 이슈와 해결 방안
- Modal, ImageModal에 forwardRef를 적용하면 useEffect의 클린업 함수에 리턴 타입을 명시를 하라는 린트 에러가 발생 합니다.. 혹시 원인 아시는 분 계신가용!?
  - 우선 void로 명시해두었습니당!

<!-- ## 🛠 피드백 반영 사항 -->