### PR TITLE
design: 버튼 컴포넌트 너비 고정 해제 

### DIFF
--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -1,14 +1,17 @@
 import { Button, BUTTON_STYLE_KEYS } from './index'
 import type { Meta, Story } from '@storybook/react'
 import type { ButtonProps } from './index'
+import { ICON_TYPES } from '../Icon'
 
 export default {
   argTypes: {
     children: {
       control: { type: 'text' }
     },
-    iconUrl: {
-      control: { type: 'text' }
+
+    icon: {
+      control: { type: 'select' },
+      options: Object.keys(ICON_TYPES)
     },
     size: {
       control: { type: 'radio' },
@@ -30,5 +33,5 @@ Default.args = {
   children: 'CTA 버튼',
   icon: 'heart',
   size: 'medium',
-  styleType: 'ghost'
+  styleType: 'solidPrimary'
 }

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -93,10 +93,10 @@ const applyButtonSizeStyle: ApplyButtonSizeStyle = (theme, styleType, size) => {
 
   switch (size) {
     case 'large':
-      return `width: 370px;
+      return `width: 100%;
               height: 64px;`
     case 'medium':
-      return `width: 370px;
+      return `width: 100%;
               height: 48px;
               border-radius: ${styleType.indexOf('outline') >= 0 && round100};`
     case 'small':


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #121 

## ⛳ 구현 사항

- [x] Button 너비 값 제거
- [x] Button 스토리 Icon prop의 컨트롤 타입 select로 변경

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->