### PR TITLE
fix: Badge 컴포넌트 children 타입 오류 수정 

### DIFF
--- a/packages/react/src/components/Badge/index.tsx
+++ b/packages/react/src/components/Badge/index.tsx
@@ -1,4 +1,4 @@
-import type { ForwardedRef, HTMLAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, ReactNode } from 'react'
 import type { Colors } from '@offer-ui/themes/colors'
 import { forwardRef } from 'react'
 import styled from '@emotion/styled'
@@ -12,9 +12,9 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   colorType: BadgeColorType
   /**
    * Badge 내부에 들어갈 내용을 정합니다.
-   * @type string
+   * @type ReactNode
    */
-  children: string
+  children: Exclude<ReactNode, 'undefined' | 'null'>
 }
 
 type StyledBadgeProps = Pick<BadgeProps, 'colorType'>

--- a/packages/react/src/components/Text/index.tsx
+++ b/packages/react/src/components/Text/index.tsx
@@ -1,4 +1,4 @@
-import type { ForwardedRef, HTMLAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, ReactNode } from 'react'
 import type { FontStyleKeys } from '@offer-ui/themes'
 import { forwardRef } from 'react'
 import styled from '@emotion/styled'
@@ -19,7 +19,7 @@ export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
    * Text로 작성할 문자열을 정합니다.
    * @type string
    */
-  children: string
+  children: Exclude<ReactNode, 'undefined' | 'null'>
   /**
    * Text의 색상을 정합니다.
    * @type string | undefined


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #125

## ⛳ 구현 사항
- Badge, Text 타입에 자바스크립트 표현식이 들어가지 않는 오류를 개선 하였습니다.

## 📚 구현 설명
```tsx
// Error ❌
<Badge>Lv.{level}</Badge>
```
위와 같이 표현식을 같이 적는 경우, 오류가 발생하여 ReactNode로 children을 변경 하였습니다.

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->