### PR TITLE
fix: Button 컴포넌트 children 타입 오류 수정 

### DIFF
--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, ForwardedRef } from 'react'
+import type { ButtonHTMLAttributes, ForwardedRef, ReactNode } from 'react'
 import { forwardRef } from 'react'
 import { Icon } from '@offer-ui/components/Icon'
 import type { IconType } from '@offer-ui/components/Icon'
@@ -28,7 +28,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * Button 내부에 작성할 문자열을 정합니다.
    * @type string
    */
-  children: string
+  children: Exclude<ReactNode, 'undefined' | 'null'>
 }
 type StyledButtonProps = StyledProps<ButtonProps, 'styleType' | 'size'>
 type StyledIconProps = StyledProps<ButtonProps, 'styleType'>


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #129 

## ⛳ 구현 사항
* Badge 컴포넌트 children 타입을 ReactNode로 수정


 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->