### PR TITLE
fix: IconButton, Divider 이슈 수정

### DIFF
--- a/packages/react/src/components/Divider/Divider.stories.tsx
+++ b/packages/react/src/components/Divider/Divider.stories.tsx
@@ -8,6 +8,12 @@ export default {
       control: { type: 'radio' },
       options: ['horizontal', 'vertical']
     },
+    gap: {
+      control: { type: 'number' }
+    },
+    length: {
+      control: { type: 'text' }
+    },
     size: {
       control: { type: 'radio' },
       options: ['regular', 'bold']

--- a/packages/react/src/components/Divider/index.tsx
+++ b/packages/react/src/components/Divider/index.tsx
@@ -11,40 +11,55 @@ export interface DividerProps extends HTMLAttributes<HTMLDivElement> {
    * @type 'bold' | 'regular'
    */
   size?: 'bold' | 'regular'
+  /** Divider 컴포넌트의 띄울 값을 정합니다.
+   * @type 'number' | 'undefined'
+   */
+  gap?: number
+  /** Divider 컴포넌트의 길이를 정합니다.
+   * @type 'string' | 'undefined'
+   */
+  length?: string
 }
-type StyledDividerProps = Pick<DividerProps, 'direction'>
 
 export const Divider = forwardRef(function Divider(
-  { direction = 'horizontal', size = 'regular', ...props }: DividerProps,
+  {
+    direction = 'horizontal',
+    size = 'regular',
+    gap = 0,
+    length,
+    ...props
+  }: DividerProps,
   ref: ForwardedRef<HTMLDivElement>
 ) {
   return (
-    <StyledDividerWrapper ref={ref} direction={direction} {...props}>
-      <StyledDivider direction={direction} size={size} />
-    </StyledDividerWrapper>
+    <StyledDivider
+      ref={ref}
+      direction={direction}
+      gap={gap}
+      length={length}
+      size={size}
+      {...props}
+    />
   )
 })
 
-const StyledDividerWrapper = styled.div<StyledDividerProps>`
-  display: ${({ direction }): string =>
-    direction === 'horizontal' ? 'block' : 'inline-block'};
-`
-const StyledDivider = styled.hr<DividerProps>`
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  display: ${({ direction }): string =>
-    direction === 'horizontal' ? 'block' : 'inline'};
-  border: ${({ theme, size }): string => {
-    const { border, colors } = theme
+const StyledDivider = styled.div<DividerProps>`
+  ${({ direction, size, theme, gap, length }): string =>
+    direction === 'vertical'
+      ? `
+        display: inline-block;
+        width: ${theme.border[size]};
+        height: ${length || '14px'};
+        margin: 0 ${gap}px;
+      `
+      : `
+        width: ${length || '100%'};
+        height: ${theme.border[size]};
+        margin: ${gap}px 0;
+      `}
 
-    switch (size) {
-      case 'bold':
-        return `${border.bold} solid ${colors.grayScale.gray05}`
-      case 'regular':
-        return `${border.regular} solid ${colors.grayScale.gray10}`
-      default:
-        return 'none'
-    }
-  }};
+  background-color:${({ size, theme }): string =>
+    size === 'bold'
+      ? theme.colors.grayScale.gray05
+      : theme.colors.grayScale.gray10}
 `

--- a/packages/react/src/components/Divider/index.tsx
+++ b/packages/react/src/components/Divider/index.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@offer-ui/types/offer'
 
-export interface DividerProps extends HTMLAttributes<HTMLDivElement> {
+export interface DividerProps extends HTMLAttributes<HTMLHRElement> {
   /** Divider 컴포넌트의 방향을 정합니다.
    * @type 'vertical' | 'horizontal' | undefined
    */
@@ -12,7 +12,7 @@ export interface DividerProps extends HTMLAttributes<HTMLDivElement> {
    * @type 'bold' | 'regular'
    */
   size?: 'bold' | 'regular'
-  /** Divider 컴포넌트의 띄울 값을 정합니다.
+  /** Divider 컴포넌트의 간격을 정합니다.
    * @type 'number' | 'undefined'
    */
   gap?: number
@@ -34,7 +34,7 @@ export const Divider = forwardRef(function Divider(
     length = '',
     ...props
   }: DividerProps,
-  ref: ForwardedRef<HTMLDivElement>
+  ref: ForwardedRef<HTMLHRElement>
 ) {
   return (
     <StyledDivider
@@ -48,7 +48,9 @@ export const Divider = forwardRef(function Divider(
   )
 })
 
-const StyledDivider = styled.div<StyledDividerProps>`
+const StyledDivider = styled.hr<StyledDividerProps>`
+  border: none;
+
   ${({ direction, size, theme, gap, length }): string =>
     direction === 'vertical'
       ? `

--- a/packages/react/src/components/Icon/Icon.stories.tsx
+++ b/packages/react/src/components/Icon/Icon.stories.tsx
@@ -1,14 +1,17 @@
 import { Icon, ICON_TYPES } from './index'
 import type { Meta, Story } from '@storybook/react'
+import { colors } from '@offer-ui/styles/themes'
 import type { IconProps } from './index'
-
-const typeKeys = Object.keys(ICON_TYPES)
 
 export default {
   argType: {
     type: {
       control: 'select',
-      option: [...typeKeys]
+      options: [...Object.keys(ICON_TYPES)]
+    },
+    color: {
+      control: 'select',
+      options: [...Object.keys(colors)]
     }
   },
   component: Icon,

--- a/packages/react/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/react/src/components/IconButton/IconButton.stories.tsx
@@ -1,8 +1,23 @@
 import type { Meta, Story } from '@storybook/react'
+import { colors } from '@offer-ui/styles/themes'
+import { ICON_TYPES } from '../Icon'
 import { IconButton } from './index'
 import type { IconButtonProps } from './index'
 
 export default {
+  argTypes: {
+    hasShadow: {
+      control: 'boolean'
+    },
+    icon: {
+      control: 'select',
+      options: [...Object.keys(ICON_TYPES)]
+    },
+    color: {
+      control: 'select',
+      options: [...Object.keys(colors)]
+    }
+  },
   component: IconButton,
   title: 'Components/IconButton'
 } as Meta<IconButtonProps>
@@ -11,8 +26,7 @@ const Template: Story<IconButtonProps> = args => <IconButton {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  colorType: 'brandPrimary',
+  color: 'brandPrimary',
   icon: 'arrowLeft',
-  shape: 'rounded',
-  size: 'small'
+  size: 24
 }

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -6,18 +6,7 @@ import type { IconType } from '@offer-ui/components/Icon'
 import styled from '@emotion/styled'
 import type { StyledProps } from '@offer-ui/types'
 
-export type IconButtonColorType = Extract<
-  ColorKeys,
-  | 'white'
-  | 'black'
-  | 'grayScale30'
-  | 'brandPrimary'
-  | 'brandPrimaryWeak'
-  | 'brandSub'
-  | 'brandSubWeak'
->
-type IconButtonSize = 'small' | 'medium' | 'large'
-type IconButtonShape = 'rounded' | 'square' | 'ghost'
+export type IconButtonColorType = ColorKeys
 
 export interface IconButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -28,14 +17,14 @@ export interface IconButtonProps
   icon: IconType
   /**
    * IconButton의 크기를 정합니다.
-   * @type 'small' | 'medium' | 'large' | undefined
+   * @type 'number' | undefined
    */
-  size?: IconButtonSize
+  size?: number
   /**
    * IconButton의 색상 타입을 정합니다.
-   * @type 'white' | 'black' | 'gray30' | 'primary' | 'primaryWeak' | 'sub' | 'subWeak' | undefined
+   * @type ColorKeys | undefined
    */
-  colorType?: IconButtonColorType
+  color?: ColorKeys
   /**
    * IconButton가 그림자 여부를 정합니다.
    * @type boolean | undefined
@@ -45,37 +34,14 @@ export interface IconButtonProps
    * IconButton의 모양을 지정합니다.
    * @type 'rounded' | 'square' | 'ghost' | undefined
    */
-  shape?: IconButtonShape
 }
 
-type StyledIconButtonProps = StyledProps<
-  IconButtonProps,
-  'size' | 'hasShadow' | 'shape' | 'colorType'
->
-type StyledIconProps = StyledProps<StyledIconButtonProps, 'shape'> & {
-  colorType: IconButtonColorType
-}
-
-const ICON_BUTTON_SIZE = {
-  large: {
-    BUTTON: 40,
-    ICON: 24
-  },
-  medium: {
-    BUTTON: 32,
-    ICON: 16
-  },
-  small: {
-    BUTTON: 24,
-    ICON: 16
-  }
-}
+type StyledIconButtonProps = StyledProps<IconButtonProps, 'hasShadow'>
 
 export const IconButton = forwardRef(function IconButton(
   {
-    colorType = 'black',
-    size = 'small',
-    shape = 'ghost',
+    color = 'black',
+    size = 16,
     hasShadow = false,
     icon,
     ...props
@@ -83,19 +49,8 @@ export const IconButton = forwardRef(function IconButton(
   ref: ForwardedRef<HTMLButtonElement>
 ) {
   return (
-    <StyledIconButton
-      {...props}
-      ref={ref}
-      colorType={colorType}
-      hasShadow={hasShadow}
-      shape={shape}
-      size={size}>
-      <StyledIcon
-        colorType={colorType}
-        shape={shape}
-        size={ICON_BUTTON_SIZE[size].ICON}
-        type={icon}
-      />
+    <StyledIconButton {...props} ref={ref} hasShadow={hasShadow}>
+      <Icon color={color} size={size} type={icon} />
     </StyledIconButton>
   )
 })
@@ -107,37 +62,13 @@ const StyledIconButton = styled.button<StyledIconButtonProps>`
   border: none;
   cursor: pointer;
 
-  ${({ size, theme, shape, hasShadow, colorType }): string => {
-    const isGhost = shape === 'ghost'
-    const isRounded = shape === 'rounded'
-
+  ${({ theme, hasShadow }): string => {
     return `
-      width: ${ICON_BUTTON_SIZE[size].BUTTON}px;
-      height: ${ICON_BUTTON_SIZE[size].BUTTON}px;
-      background-color: ${isGhost ? 'transparent' : theme.colors[colorType]};
-      border-radius: ${isRounded ? theme.radius.round100 : 'none'};
+  
+      background-color: transparent;
       box-shadow: ${
-        hasShadow && !isGhost
-          ? `0px 2px 10px ${theme.colors.dimOpacity25}`
-          : 'none'
+        hasShadow ? `0px 2px 10px ${theme.colors.dimOpacity25}` : 'none'
       };
     `
   }}
-`
-
-const StyledIcon = styled(Icon)<StyledIconProps>`
-  color: ${({ theme, colorType, shape }): string => {
-    const isBlack = shape !== 'ghost' && colorType === 'white'
-    const isGhost = shape !== 'ghost'
-
-    if (isBlack) {
-      return theme.colors.black
-    }
-
-    if (isGhost) {
-      return theme.colors.white
-    }
-
-    return theme.colors[colorType]
-  }};
 `

--- a/packages/react/src/components/ImageModal/index.tsx
+++ b/packages/react/src/components/ImageModal/index.tsx
@@ -182,9 +182,9 @@ export const ImageModal = forwardRef(function ImageModal(
           <StyledGradient direction="top" />
           <StyledGradient direction="bottom" />
           <StyledCloseIcon
-            colorType="grayScale30"
+            color="grayScale30"
             icon="close"
-            size="medium"
+            size={24}
             onClick={onClose}
           />
           <StyledImageContainer

--- a/packages/react/src/components/Input/ChattingInput.tsx
+++ b/packages/react/src/components/Input/ChattingInput.tsx
@@ -36,12 +36,11 @@ export const ChattingInput = forwardRef(function ChattingInput(
         {...props}
       />
       <StyledIconButton
-        colorType={isDisabled ? 'brandPrimaryWeak' : 'brandPrimary'}
+        color="white"
         disabled={isDisabled}
         icon="arrowUp"
         isSmall={isSmall}
-        shape="rounded"
-        size="medium"
+        size={16}
       />
     </StyledInputForm>
   )
@@ -93,8 +92,17 @@ const StyledIconButton = styled(IconButton)<StyledIconButtonProps>`
   position: absolute;
   justify-content: center;
   align-items: center;
+  width: 32px;
+  height: 32px;
   border: none;
   cursor: pointer;
+
+  ${({ theme, disabled }): string => `
+    background-color: ${
+      disabled ? theme.colors.brandPrimaryWeak : theme.colors.brandPrimary
+    };
+    border-radius: ${theme.radius.round100};
+  `}
 
   ${({ isSmall }): string => {
     if (isSmall) {
@@ -110,9 +118,6 @@ const StyledIconButton = styled(IconButton)<StyledIconButtonProps>`
     `
   }}
 
-  ${({ theme }): string => `
-    border-radius: ${theme.radius.round100};
-  `}
 
   &:disabled {
     cursor: default;

--- a/packages/react/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/react/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -11,10 +11,8 @@ const Template: Story<ToggleButtonProps> = args => <ToggleButton {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  colorType: 'grayScale30',
+  color: 'grayScale30',
   icon: 'heart',
-  shape: 'rounded',
-  size: 'medium',
-  styleType: 'fill',
-  toggleColorType: 'brandPrimary'
+  size: 16,
+  toggleColor: 'brandPrimary'
 }

--- a/packages/react/src/components/ToggleButton/index.tsx
+++ b/packages/react/src/components/ToggleButton/index.tsx
@@ -1,10 +1,8 @@
 import type { ForwardedRef, MouseEventHandler } from 'react'
 import { forwardRef, useState } from 'react'
-import type {
-  IconButtonColorType,
-  IconButtonProps
-} from '@offer-ui/components/IconButton'
+import type { ColorKeys } from '@offer-ui/styles/themes'
 import { IconButton } from '@offer-ui/components/IconButton'
+import type { IconButtonProps } from '@offer-ui/components/IconButton'
 import type { IconType } from '@offer-ui/components/Icon'
 
 type FillIconType = Extract<
@@ -38,14 +36,14 @@ interface StrokeToggleButton {
 export type ToggleButtonProps = IconButtonProps & {
   /**
    * ToggleButton의 색상 타입을 정합니다.
-   * @type 'white' | 'black' | 'gray30' | 'primary' | 'primaryWeak' | 'sub' | 'subWeak' | undefined
+   * @type ColorKeys | undefined
    */
-  colorType?: IconButtonColorType
+  color?: ColorKeys
   /**
    * ToggleButton이 toggle된 경우의 색상 타입을 정합니다.
    * @type 'white' | 'black' | 'gray30' | 'primary' | 'primaryWeak' | 'sub' | 'subWeak' | undefined
    */
-  toggleColorType?: IconButtonColorType
+  toggleColor?: ColorKeys
 } & ToggleButtonType
 
 type ToggleButtonType = FillToggleButton | StrokeToggleButton
@@ -54,8 +52,8 @@ export const ToggleButton = forwardRef(function ToggleButton(
   {
     onClick,
     styleType = 'stroke',
-    colorType = 'black',
-    toggleColorType = colorType,
+    color = 'black',
+    toggleColor = color,
     icon,
     ...props
   }: ToggleButtonProps,
@@ -65,7 +63,7 @@ export const ToggleButton = forwardRef(function ToggleButton(
   const isFillType = styleType === 'fill'
   const toggleIcon = isFillType ? `${icon}Fill` : icon
   const renderIcon = {
-    color: isToggle ? toggleColorType : colorType,
+    color: isToggle ? toggleColor : color,
     icon: isToggle ? toggleIcon : icon
   }
 
@@ -78,7 +76,7 @@ export const ToggleButton = forwardRef(function ToggleButton(
   return (
     <IconButton
       ref={ref}
-      colorType={renderIcon.color}
+      color={renderIcon.color}
       icon={renderIcon.icon as IconType}
       onClick={handleClick}
       {...props}


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #132 

## ⛳ 구현 사항
* IconButton 사이즈 조절이 되지 않는 이슈 수정 및 변경사항 적용
* Divider 간격, 사이즈 조절 prop 추가

## 📚 구현 설명
* Icon Button은 구두로 회의를 통해 ghost 타입만 남겨두는 것으로 결정하여 수정완료 했습니다.
* Divider 사이즈 조절을 위한 prop들이 받아지지 않고있어 추가했습니다.

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->