### PR TITLE
fix: Badge 컴포넌트 텍스트 색상 적용 안되는 이슈 수정

### DIFF
--- a/packages/react/src/components/Badge/index.tsx
+++ b/packages/react/src/components/Badge/index.tsx
@@ -1,5 +1,4 @@
 import type { ForwardedRef, HTMLAttributes, ReactNode } from 'react'
-import type { Colors } from '@offer-ui/themes/colors'
 import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import { Text } from '@offer-ui/components/Text'
@@ -18,7 +17,21 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 type StyledBadgeProps = Pick<BadgeProps, 'colorType'>
-type ApplyColorScheme = (colorType: BadgeColorType, colors: Colors) => string
+
+const BADGE_COLORS = {
+  orange: {
+    background: 'brandPrimaryWeak',
+    text: 'brandPrimary'
+  },
+  gray: {
+    background: 'grayScale10',
+    text: 'grayScale50'
+  },
+  purple: {
+    background: 'brandSubWeak',
+    text: 'brandSub'
+  }
+} as const
 
 export const Badge = forwardRef(function Badge(
   { colorType, children, ...props }: BadgeProps,
@@ -26,32 +39,12 @@ export const Badge = forwardRef(function Badge(
 ) {
   return (
     <StyledBadge ref={ref} colorType={colorType} {...props}>
-      <Text styleType="caption01M">{children}</Text>
+      <Text color={BADGE_COLORS[colorType].text} styleType="caption01M">
+        {children}
+      </Text>
     </StyledBadge>
   )
 })
-
-const applyColorScheme: ApplyColorScheme = (colorScheme, colors) => {
-  switch (colorScheme) {
-    case 'gray':
-      return `
-        color: ${colors.grayScale50};
-        background: ${colors.grayScale10};
-      `
-    case 'orange':
-      return `
-          color: ${colors.brandPrimary};
-          background: ${colors.brandPrimaryWeak};
-        `
-    case 'purple':
-      return `
-          color: ${colors.brandSub};
-          background: ${colors.brandSubWeak};
-        `
-    default:
-      return ''
-  }
-}
 
 const StyledBadge = styled.div<StyledBadgeProps>`
   display: inline-block;
@@ -59,6 +52,6 @@ const StyledBadge = styled.div<StyledBadgeProps>`
   padding: 2px 6px;
   text-align: center;
   font-feature-settings: normal;
-  ${({ colorType, theme }): string =>
-    applyColorScheme(colorType, theme.colors)};
+  background-color: ${({ colorType, theme }): string =>
+    theme.colors[BADGE_COLORS[colorType].background]};
 `


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #147 

## ⛳ 구현 사항
* Badge 컴포넌트 텍스트 색상 적용 안되는 이슈 수정

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

## 🔥 이슈와 해결 방안 
* Text 컴포넌트 내부에서 이미 컬러 값을 지정하고 있기 때문에 상위에서 전해주는 컬러값이 우선순위에서 밀려나서 적용되지 않는 이슈
   * Text 컴포넌트에 직접 color를 prop으로 내려주는 방식으로 수정 


<!-- ## 🛠 피드백 반영 사항 -->