### PR TITLE
design: Text 기본 색상값 제거

### DIFF
--- a/packages/react/src/components/Text/index.tsx
+++ b/packages/react/src/components/Text/index.tsx
@@ -24,7 +24,7 @@ export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
    * Text의 색상을 정합니다.
    * @type ColorKeys | undefined
    */
-  color?: ColorKeys
+  color?: ColorKeys | ''
 }
 
 type StyledTextProps = StyledProps<TextProps, 'styleType' | 'color'>
@@ -34,7 +34,7 @@ export const Text = forwardRef(function Text(
     tag = 'span',
     children,
     styleType: textStyle = 'body01M',
-    color = 'grayScale90',
+    color = '',
     ...props
   }: TextProps,
   ref: ForwardedRef<HTMLSpanElement>
@@ -52,7 +52,7 @@ export const Text = forwardRef(function Text(
 })
 
 const StyledText = styled.span<StyledTextProps>`
-  color: ${({ color, theme }): string => theme.colors[color]};
+  color: ${({ color, theme }): string => color && theme.colors[color]};
 
   ${({ theme, styleType }): string => theme.fonts[styleType]};
 `


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #152 

## ⛳ 구현 사항
* Text 사용시 기본 색상 지정이 되어있어 상위에서 색상 지정이 불가능하기 때문에 이를 제거합니다.

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->