### PR TITLE
refactor: Selectbox 타입 이슈로 인해 any로 item 타입 확장, ReactNode관련 타입 재지정

### DIFF
--- a/packages/react/src/components/Badge/index.tsx
+++ b/packages/react/src/components/Badge/index.tsx
@@ -13,7 +13,7 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
    * Badge 내부에 들어갈 내용을 정합니다.
    * @type ReactNode
    */
-  children: Exclude<ReactNode, 'undefined' | 'null'>
+  children: Exclude<ReactNode, undefined | null>
 }
 
 type StyledBadgeProps = Pick<BadgeProps, 'colorType'>

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -33,7 +33,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * Button 내부에 작성할 문자열을 정합니다.
    * @type string
    */
-  children: Exclude<ReactNode, 'undefined' | 'null'>
+  children: Exclude<ReactNode, undefined | null>
 }
 type StyledButtonProps = StyledProps<
   ButtonProps,

--- a/packages/react/src/components/SelectBox/SelectBox.stories.tsx
+++ b/packages/react/src/components/SelectBox/SelectBox.stories.tsx
@@ -22,7 +22,9 @@ export default {
 const Template: Story<SelectBoxProps> = args => {
   const [value, setValue] = useState<string>('select1')
 
-  const handleChange: SelectOnChangeHandler<string> = (item): void => {
+  const handleChange: SelectOnChangeHandler<{ code: string; name: string }> = (
+    item
+  ): void => {
     setValue(item.code)
   }
 

--- a/packages/react/src/components/Text/index.tsx
+++ b/packages/react/src/components/Text/index.tsx
@@ -19,7 +19,7 @@ export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
    * Text로 작성할 문자열을 정합니다.
    * @type string
    */
-  children: Exclude<ReactNode, 'undefined' | 'null'>
+  children: Exclude<ReactNode, undefined | null>
   /**
    * Text의 색상을 정합니다.
    * @type ColorKeys | undefined

--- a/packages/react/src/types/offer.d.ts
+++ b/packages/react/src/types/offer.d.ts
@@ -1,11 +1,10 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /** SelectBox  */
-export interface SelectItem<T = string> {
-  code: T
-  name: string
+export interface SelectItem {
+  code: any
+  name: any
 }
-export declare type SelectOnChangeHandler<T = string> = (
-  item: SelectItem<T>
-) => void
+export declare type SelectOnChangeHandler<T = any> = (item: T) => void
 
 /**  ImageUploader */
 export interface ImageInfo {


### PR DESCRIPTION
## ⛳ 구현 사항
- SelectBox 내부 엄격한 타입 선언으로 인해 외부 사용처에서 타입 지정이 어려워 any로 변경하였습니다...
- ReactNode관련 Exclude 되어있는 string을 해당 타입으로 재지정하였습니다.
