### PR TITLE
refactor: { code, name }으로 받는 형태에 대한 타입 확장

### DIFF
--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -62,7 +62,6 @@
         "format": ["PascalCase"]
       }
     ],
-    "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-for-in-array": "error",
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/no-confusing-void-expression": "error",

--- a/packages/react/src/components/CheckBox/hooks/index.ts
+++ b/packages/react/src/components/CheckBox/hooks/index.ts
@@ -3,14 +3,14 @@ import type { ReactNode } from 'react'
 import { useState } from 'react'
 
 interface CheckItemType {
-  code: string
+  code: any
   checked: boolean
-  element: ReactNode
+  element: Exclude<ReactNode, undefined | null>
 }
 
 interface ReturnType {
   checkList: CheckItemType[]
-  onCheckItem(code: string): void
+  onCheckItem(code: any): void
 }
 
 const useCheckList = (checkList: CheckItemType[]): ReturnType => {

--- a/packages/react/src/components/CheckBox/index.tsx
+++ b/packages/react/src/components/CheckBox/index.tsx
@@ -15,7 +15,7 @@ export interface CheckBoxProps extends FormHTMLAttributes<HTMLFormElement> {
   /** CheckBox 컴포넌트에 사용될 key 값인 code를 정합니다
    * @type string
    */
-  code: string
+  code: any
   /** CheckBox 컴포넌트에 사용될 checked 유무를 확인할 checked를 정합니다.
    * @type string
    */
@@ -31,7 +31,7 @@ export interface CheckBoxProps extends FormHTMLAttributes<HTMLFormElement> {
   /** CheckBox 컴포넌트를 눌렀을때 실행할 함수를 정합니다.
    * @type void
    */
-  onCheck(code: string): void | undefined
+  onCheck(code: any): void | undefined
   /** CheckBox 컴포넌트에 추가로 render시킬 함수를 정합니다.
    * @type void
    */

--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -15,12 +15,9 @@ export interface RadioProps extends FormHTMLAttributes<HTMLFormElement> {
    */
   formName: string
   /** Radio 컴포넌트에 보여질 옵션들을 정합니다
-   * @type { code: string, name: string } []
+   * @type any
    */
-  items: {
-    code: string
-    name: string
-  }[]
+  items: any
   /** Radio 컴포넌트 내부 옵션의 방향을 정합니다.
    * @type 'horizontal' | 'vertical'
    */
@@ -54,7 +51,7 @@ export const Radio = forwardRef(function Radio(
     onChange(e)
   }
 
-  const radioList = items?.map(({ code, name }) => (
+  const radioList = items?.map(({ code, name }: any) => (
     <StyledInputWrapper key={code} className={`${direction}`}>
       <StyledInput
         id={code}

--- a/packages/react/src/components/SelectBox/index.tsx
+++ b/packages/react/src/components/SelectBox/index.tsx
@@ -1,8 +1,4 @@
-import type {
-  SelectItem,
-  SelectOnChangeHandler,
-  StyledProps
-} from '@offer-ui/types'
+import type { SelectOnChangeHandler, StyledProps } from '@offer-ui/types'
 import { Icon } from '@offer-ui/components/Icon'
 import type { IconProps } from '@offer-ui/components/Icon'
 import type { ReactElement } from 'react'
@@ -28,9 +24,9 @@ interface DefaultSelectBoxProps {
    */
   placeholder?: string
   /** SelectBox의 옵션들을 정합니다.
-   * @type { text: string, value: string | number }[]
+   * @type any
    */
-  items: SelectItem[]
+  items: any
 }
 
 interface UnControlledSelectBoxProps extends DefaultSelectBoxProps {
@@ -80,7 +76,8 @@ export const SelectBox = ({
   const value = isControlled ? controlledValue : uncontrolledValue
 
   const ref = useClose<HTMLDivElement>({ onClose: setIsOpen })
-  const text = items.find(option => option.code === value)?.name || placeholder
+  const text =
+    items.find((option: any) => option.code === value)?.name || placeholder
   const isEmpty = value === ''
 
   const handleOpenOptions = (): void => {
@@ -119,7 +116,7 @@ export const SelectBox = ({
       {isOpen && (
         <StyledOptionListWrapper size={size}>
           <StyledOptionList>
-            {items?.map(item => (
+            {items?.map((item: any) => (
               <StyledOptionsWrapper
                 key={item.code}
                 isSelected={value === item.code}

--- a/packages/react/src/types/offer.d.ts
+++ b/packages/react/src/types/offer.d.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/** SelectBox  */
-export interface SelectItem {
+export interface Option {
   code: any
   name: any
 }


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #168 

## ⛳ 구현 사항
-  { code, name }으로 받는 형태에 대한 타입 확장
- any 제한하는 린트 룰 제거