### PR TITLE
fix: Icon 컴포넌트 smile 이  비율에 따라 stroke-width 가 유지가 안되고 깨지는 현상 수정

### DIFF
--- a/packages/react/public/icons/smile.svg
+++ b/packages/react/public/icons/smile.svg
@@ -1,6 +1,6 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
 <path d="M8.625 11.25C9.24632 11.25 9.75 10.7463 9.75 10.125C9.75 9.50368 9.24632 9 8.625 9C8.00368 9 7.5 9.50368 7.5 10.125C7.5 10.7463 8.00368 11.25 8.625 11.25Z" fill="currentColor"/>
 <path d="M15.375 11.25C15.9963 11.25 16.5 10.7463 16.5 10.125C16.5 9.50368 15.9963 9 15.375 9C14.7537 9 14.25 9.50368 14.25 10.125C14.25 10.7463 14.7537 11.25 15.375 11.25Z" fill="currentColor"/>
-<path d="M15.9001 14.25C15.5036 14.9331 14.9347 15.5 14.2503 15.8941C13.5658 16.2882 12.7899 16.4956 12.0001 16.4956C11.2103 16.4956 10.4344 16.2882 9.74993 15.8941C9.0655 15.5 8.49658 14.9331 8.1001 14.25" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M15.9001 14.25C15.5036 14.9331 14.9347 15.5 14.2503 15.8941C13.5658 16.2882 12.7899 16.4956 12.0001 16.4956C11.2103 16.4956 10.4344 16.2882 9.74993 15.8941C9.0655 15.5 8.49658 14.9331 8.1001 14.25" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
 </svg>


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #192 

## ⛳ 구현 사항

- Icon 컴포넌트 smile 이 width, height, stroke-width 가 유지가 안되고 깨지는 현상 확인 후 수정

## 📚 구현 설명

이와 같이 동일하게 stroke-width 가 2인데 smile 만 두껍다. 
따라서 vector-effect 의 "non-scaling-stroke" 이라는 비율에 따라 변하지 않게 하는 옵션을 추가하여 해결하였슴당!
[mdn 링크](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/vector-effect)
<img width="303" alt="image" src="https://github.com/price-offer/offer-fe/assets/66211721/417b5c0f-4420-40b6-be1f-6cdb385f16a7">

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->