### PR TITLE
design: 상위 요소에 의해 사이즈 틀어지는 이슈 수정

### DIFF
--- a/packages/react/src/components/Avatar/index.tsx
+++ b/packages/react/src/components/Avatar/index.tsx
@@ -1,3 +1,5 @@
+import type { SerializedStyles } from '@emotion/react'
+import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { Icon } from '@offer-ui/components/Icon'
 import { Image } from '@offer-ui/components/Image'
@@ -72,9 +74,13 @@ const StyledBlankAvatarWrapper = styled.div<StyledBlankAvatarWrapperProps>`
   justify-content: center;
   align-items: center;
   border-radius: 100%;
-  ${({ theme, size }): string => `
+  ${({ theme, size }): SerializedStyles => css`
     width: ${AVATAR_WRAPPER_SIZE[size]};
     height: ${AVATAR_WRAPPER_SIZE[size]};
+    min-width: ${AVATAR_WRAPPER_SIZE[size]};
+    min-height: ${AVATAR_WRAPPER_SIZE[size]};
+    max-width: ${AVATAR_WRAPPER_SIZE[size]};
+    max-height: ${AVATAR_WRAPPER_SIZE[size]};
     background-color: ${theme.colors.grayScale05};
   `}
 `

--- a/packages/react/src/components/Image/index.tsx
+++ b/packages/react/src/components/Image/index.tsx
@@ -1,3 +1,5 @@
+import type { SerializedStyles } from '@emotion/react'
+import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { useImage } from '@offer-ui/hooks'
 import type { StyledProps } from '@offer-ui/types'
@@ -51,7 +53,7 @@ type ApplyShapeParams = {
   width: string
   height: string
 }
-type ApplyShape = (params: ApplyShapeParams) => string
+type ApplyShape = (params: ApplyShapeParams) => SerializedStyles
 
 export const Image = forwardRef(function Image(
   {
@@ -135,9 +137,13 @@ const StyledImage = styled.img<StyledImgProps>`
 `
 
 const applyShape: ApplyShape = ({ radius, boxSize, width, height }) => {
-  return `
+  return css`
     width: ${width || boxSize};
     height: ${height || boxSize};
+    min-width: ${width || boxSize};
+    min-height: ${height || boxSize};
+    max-width: ${width || boxSize};
+    max-height: ${height || boxSize};
     border-radius: ${radius};
   `
 }

--- a/packages/react/src/components/Radio/Default.tsx
+++ b/packages/react/src/components/Radio/Default.tsx
@@ -5,6 +5,11 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, ChangeEvent, ReactNode } from 'react'
 import { Input } from './Input'
 
+export const DIRECTION = {
+  VERTICAL: 'vertical',
+  HORIZONTAL: 'horizontal'
+} as const
+
 type CommonProps = {
   /** Radio 컴포넌트의 이름을 정합니다.(input name에 사용)
    * @type string
@@ -13,7 +18,7 @@ type CommonProps = {
   /** Radio 컴포넌트 내부 옵션의 방향을 정합니다.
    * @type 'horizontal' | 'vertical'
    */
-  direction: 'horizontal' | 'vertical'
+  direction: typeof DIRECTION[keyof typeof DIRECTION]
   /** Radio 컴포넌트의 값이 변경되는 경우 실행할 함수를 정합니다.
    * @type void
    */
@@ -42,7 +47,7 @@ export const Default = forwardRef(function Radio(
     formName,
     onChange,
     items,
-    direction = 'horizontal',
+    direction = DIRECTION.HORIZONTAL,
     children,
     ...props
   }: RadioProps,
@@ -65,8 +70,10 @@ export const Default = forwardRef(function Radio(
 })
 
 const Form = styled.form<StyledFormProps>`
-  display: ${({ direction }): string =>
-    direction === 'vertical' ? 'block' : 'flex'};
+  display: flex;
+
+  flex-direction: ${({ direction }): string =>
+    direction === DIRECTION.VERTICAL ? 'column' : 'row'};
   gap: 10px;
 `
 export const Label = styled.label`

--- a/packages/react/src/components/Radio/Input.tsx
+++ b/packages/react/src/components/Radio/Input.tsx
@@ -38,6 +38,10 @@ const CheckMark = styled.span`
   position: relative;
   height: 20px;
   width: 20px;
+  min-height: 20px;
+  min-width: 20px;
+  max-height: 20px;
+  max-width: 20px;
   background-color: ${({ theme }): string => theme.colors.white};
   border: solid ${({ theme }): string => theme.colors.grayScale10};
   border-radius: ${({ theme }): string => theme.radius.round100};

--- a/packages/react/src/components/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/Radio/Radio.stories.tsx
@@ -3,12 +3,19 @@ import { Icon } from '@offer-ui/components'
 import { action } from '@storybook/addon-actions'
 import type { Meta, Story } from '@storybook/react'
 import type { ChangeEvent } from 'react'
+import { DIRECTION } from './Default'
 import type { RadioProps } from './index'
 import { Radio } from './index'
 
 export default {
   component: Radio,
-  title: 'Components/Radio'
+  title: 'Components/Radio',
+  argTypes: {
+    direction: {
+      control: 'radio',
+      options: Object.values(DIRECTION)
+    }
+  }
 } as Meta<RadioProps>
 
 const moodList: IconType[] = ['sad', 'meh', 'smile']


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #200 

## ⛳ 구현 사항
* 상위 요소에 의해 사이즈 틀어지는 이슈 수정
   * Radio
   * Image
   * Avatar

## 📚 구현 설명

* 외부에서 스타일이 틀어지는 이슈가 있어 wrapping을 통해 사이즈를 조절해야하는 이슈가 있었습니다. 컴포넌트에 직접 width, height를 전달해 사이즈를 지정하는 의미가 있도록 하기 위해 **`min-width`**, **`max-width`** 를 지정하여 컴포넌트가 고정값으로 가질 수 있도록 했습니다.
   * 상위에서 사이즈를 자유롭게 조절하기를 원한다면 100%로 지정하여 wrapping을 통해 사이즈를 조절하도록 합니다.



 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->