### PR TITLE
design: Selectbox 컴포넌트 dark일 때 스타일 이슈 수정 

### DIFF
--- a/.changeset/three-cobras-agree.md
+++ b/.changeset/three-cobras-agree.md
@@ -1,0 +1,5 @@
+---
+"@offer-ui/react": patch
+---
+
+design: selectbox darkmode 스타일 이슈 수정

--- a/packages/react/src/components/SelectBox/index.tsx
+++ b/packages/react/src/components/SelectBox/index.tsx
@@ -105,7 +105,7 @@ export const SelectBox = ({
         isEmpty={isEmpty}
         size={size}
         onClick={handleOpenOptions}>
-        <Text styleType="body02M">{text}</Text>
+        <span>{text}</span>
         <StyledTriggerArrow
           color={getIconColor()}
           size={16}
@@ -146,6 +146,7 @@ const StyledTriggerWrapper = styled.div<Omit<StyledSelectProps, 'isSelected'>>`
     position: relative;
     width: 100%;
     cursor: pointer;
+    ${theme.fonts.body02M}
     ${applyColorScheme(colorType, theme)}
     ${applySize(size, theme)}
     color:${getFontColor({ colorType, isEmpty, size, theme })};
@@ -177,7 +178,7 @@ const StyledOptionList = styled.ul`
     border: 1px solid ${theme.colors.grayScale10};
     ${theme.mediaQuery.desktop} {
       font-size: 12px;
-      box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.15);
+      box-shadow: 0px 2px 6px rgba(108, 63, 63, 0.15);
     }
     ${theme.mediaQuery.tablet} {
       font-size: 14px;


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #240 

## ⛳ 구현 사항
* Selectbox 컴포넌트 dark일 때 폰트 색상 white 적용되도록 수정


 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->