### PR TITLE
fix: Input.Edit 가격이 아닌 경우도 가능하도록

### DIFF
--- a/.changeset/shiny-cars-attend.md
+++ b/.changeset/shiny-cars-attend.md
@@ -1,0 +1,5 @@
+---
+"@offer-ui/react": patch
+---
+
+- Input.Edit에 isPrice prop 추가

--- a/packages/react/src/components/Input/Edit.tsx
+++ b/packages/react/src/components/Input/Edit.tsx
@@ -24,6 +24,11 @@ export type EditInputProps = InputProps & {
    * @type string | undefined
    */
   guideMessage?: string
+  /**
+   * Input 값으로 가격을 받는지 여부를 정합니다.
+   * @type boolean | undefined
+   */
+  isPrice?: boolean
 }
 type StyledInputProps = {
   isSmall: boolean
@@ -40,6 +45,7 @@ export const Edit = forwardRef(function Edit(
     inputSize = 'small',
     width = '100%',
     onChange,
+    isPrice,
     ...props
   }: EditInputProps,
   ref: ForwardedRef<HTMLInputElement>
@@ -48,8 +54,11 @@ export const Edit = forwardRef(function Edit(
   const isSmall = isSmallSize(inputSize)
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = e => {
-    const numberValue = convertToNumber(e.target.value)
-    e.target.value = numberValue > 0 ? toLocaleCurrency(numberValue) : ''
+    if (isPrice) {
+      const numberValue = convertToNumber(e.target.value)
+
+      e.target.value = numberValue > 0 ? toLocaleCurrency(numberValue) : ''
+    }
 
     onChange?.(e)
   }


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #261 

## ⛳ 구현 사항
* Input.Edit 가격이 아닌 경우도 가능하도록

## 📚 구현 설명
isPrice 아닌 상황에도 사용되는 곳이 있어 수정합니다.

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->